### PR TITLE
Removed unsupported named argument for service

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,8 +3,7 @@ parameters:
 services:
     azine_mailgun.service:
         class: Azine\MailgunWebhooksBundle\Services\AzineMailgunService
-        arguments:
-          managerRegistry:      "@doctrine"
+        arguments: ["@doctrine"]
 
     azine.mailgun.webhooks.bundle.twig.filters:
         class: Azine\MailgunWebhooksBundle\Services\AzineMailgunTwigExtension


### PR DESCRIPTION
This breaks on Symfony 3.3.0-Beta1 because of [changes in DI](https://github.com/symfony/symfony/pull/21383#issuecomment-275839344). Named keys have never been officially supported.