### PR TITLE
remove britle/not required build step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 matrix:
   allow_failures:
     - env: SYMFONY_VERSION=dev-master
-- php: nightly
+    - php: nightly
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,12 @@ matrix:
 sudo: false
 
 before_install:
-  - mv /home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ~/xdebug.ini
   - composer self-update
 
 before_script:
   - phpenv config-add travis.php.ini
   - travis_wait composer require symfony/symfony:${SYMFONY_VERSION} --prefer-source --no-update -v
   - travis_wait composer install --prefer-source
-  - mv ~/xdebug.ini /home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
-#  - ls -a /home/travis/build/azine/* -R
 
 script:
   - phpunit --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
 
 sudo: false
 
+cache:
+  directories:
+  - $HOME/.composer/cache
+
 before_install:
   - composer self-update
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,18 +2,20 @@ language: php
 
 php:
   - 5.6
+  - 7.1
+  - 7.2
+  - nightly
 
 env:
   - SYMFONY_VERSION=2.7.*
   - SYMFONY_VERSION=2.8.*
-  - SYMFONY_VERSION=3.0.*
-  - SYMFONY_VERSION=3.1.*
-  - SYMFONY_VERSION=3.2.*
+  - SYMFONY_VERSION=3.3.*
   - SYMFONY_VERSION=dev-master
 
 matrix:
   allow_failures:
     - env: SYMFONY_VERSION=dev-master
+- php: nightly
 
 sudo: false
 


### PR DESCRIPTION
moving the xdebug.ini around is not strictly required and it breaks when the php-version is "nightly"