### PR TITLE
Fix tag param when tag is sent using X-Mailgun-Tag header over SMTP

### DIFF
--- a/Controller/MailgunEventController.php
+++ b/Controller/MailgunEventController.php
@@ -303,6 +303,11 @@ class MailgunEventController extends Controller
             $event->setTag($params['tag']);
             unset($params['tag']);
         }
+        // x-mailgun-tag
+        if (array_key_exists('x-mailgun-tag', $params)) {
+            $event->setTag($params['x-mailgun-tag']);
+            unset($params['x-mailgun-tag']);
+        }
         // userAgent
         if (array_key_exists('user-agent', $params)) {
             $event->setUserAgent($params['user-agent']);


### PR DESCRIPTION
When sending emails using smtp, for setting tags you have to use X-Mailgun-Tag header, but when using this header, the response from the webhook is **x-mailgun-tag** instead of **tag**.
https://documentation.mailgun.com/en/latest/user_manual.html#sending-via-smtp
