### PR TITLE
Upgrade to PHP 8.5 / Symfony 7.4 and modernize CI, PHPUnit and composer settings

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   test:
-    name: PHPUnit (PHP ${{ matrix.php-version }}, deps: ${{ matrix.dependency-mode }})
+    name: "PHPUnit (PHP ${{ matrix.php-version }}, deps: ${{ matrix.dependency-mode }})"
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: PHPUnit (PHP ${{ matrix.php-version }}, deps: ${{ matrix.dependency-mode }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['8.5']
+        dependency-mode: ['stable', 'lowest']
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mailparse
+          coverage: none
+
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Cache Composer
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.composer/cache/files
+            ~/.cache/composer/files
+          key: ${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependency-mode }}-${{ hashFiles('composer.json') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php-version }}-${{ matrix.dependency-mode }}-
+
+      - name: Install dependencies (stable)
+        if: matrix.dependency-mode == 'stable'
+        run: composer update --no-interaction --prefer-dist
+
+      - name: Install dependencies (lowest)
+        if: matrix.dependency-mode == 'lowest'
+        run: composer update --no-interaction --prefer-lowest --prefer-stable
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit -c phpunit.xml.dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,50 +1,20 @@
+# Legacy CI kept for backward compatibility.
+# GitHub Actions (.github/workflows/phpunit.yml) is the primary CI pipeline.
 language: php
 
 php:
-  - 7.1
-  - 7.2
+  - 8.5
 
 env:
-  - SYMFONY_VERSION=lts:^2
-  - SYMFONY_VERSION=lts:^3
-  - SYMFONY_VERSION=flex:^1
-  - SYMFONY_VERSION=lts:^4
-
-
-matrix:
-  fast_finish: true
-  include:
-    - env:
-        - SYMFONY_VERSION=lts:^2
-        - dependencies=lowest
-
-    - env:
-        - SYMFONY_VERSION=lts:^3
-        - cs_fixer=cs_dry_run
-
-  allow_failures:
-    - env: SYMFONY_VERSION=lts:^4
+  - DEPENDENCIES=stable
+  - DEPENDENCIES=lowest
 
 cache:
   directories:
     - $HOME/.composer/cache
 
-before_install:
-  - mv /home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ~/xdebug.ini
-  - composer self-update
-
 before_script:
-  - phpenv config-add travis.php.ini
-  - travis_wait composer require symfony/${SYMFONY_VERSION} --prefer-source --no-update -v
-  - mv ~/xdebug.ini /home/travis/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini
-  - if [ "$dependencies" != "lowest" ]; then travis_wait composer update --prefer-source; fi;
-  - if [ "$dependencies" = "lowest" ]; then travis_wait composer update --prefer-lowest --prefer-stable -n; fi;
+  - if [ "$DEPENDENCIES" = "lowest" ]; then composer update --prefer-lowest --prefer-stable -n; else composer update --prefer-dist -n; fi
 
 script:
-  - travis_wait vendor/phpunit/phpunit/phpunit --coverage-text --coverage-clover=coverage.clover Tests/
-  - wget https://scrutinizer-ci.com/ocular.phar
-  - php ocular.phar code-coverage:upload --format=php-clover coverage.clover
-  - if [ "$cs_fixer" = "cs_dry_run" ]; then php vendor/friendsofphp/php-cs-fixer/php-cs-fixer --diff --dry-run -v fix --config=.php_cs.dist ./; fi;
-
-notifications:
-  email: travis@azine-it.ch
+  - vendor/bin/phpunit -c phpunit.xml.dist

--- a/README.md
+++ b/README.md
@@ -15,6 +15,32 @@ This bundle captures this data. You can search for, filter and display log-entri
 delete them when you don't need them anymore (or when you need to save some disk-space).  
 
 
+
+## Requirements (current)
+- PHP **8.5+**
+- Symfony **7.4** components
+- Twig **3.x**
+- Doctrine ORM **3.3+**
+- PHP extension: **mailparse**
+
+## Local test execution
+1. Install dependencies:
+   ```bash
+   composer update
+   ```
+2. Run tests:
+   ```bash
+   vendor/bin/phpunit -c phpunit.xml.dist
+   ```
+3. (Optional) Validate Composer metadata:
+   ```bash
+   composer validate --strict
+   ```
+
+## CI
+GitHub Actions is the primary CI and runs on every push and pull request via `.github/workflows/phpunit.yml`.
+It tests stable and lowest dependency installs on PHP 8.5.
+
 ## Features
 - capture all data that mailgun.com can post via the "webhooks" provided by mailgun.com => http://documentation.mailgun.com/user_manual.html#webhooks
 - display lists of event entries with search and filter functionality

--- a/Tests/Command/CheckIpAddressIsBlacklistedCommandTest.php
+++ b/Tests/Command/CheckIpAddressIsBlacklistedCommandTest.php
@@ -72,18 +72,18 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
             'api_blacklist_check_link' => 'https://api.example.com/v2/token/blacklist-check/ipv4/198.51.100.42/',
         );
 
-        $this->entityRepository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->setMethods(array('getLastKnownSenderIpData', 'findBy'))->getMock();
+        $this->entityRepository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->onlyMethods(array('getLastKnownSenderIpData', 'findBy'))->getMock();
         $this->entityRepository->expects($this->any())->method('getLastKnownSenderIpData')->will($this->returnValue(array('ip' => '198.51.100.42', 'timestamp' => '1552971782')));
 
-        $this->entityManager = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->setMethods(array('getRepository'))->getMock();
+        $this->entityManager = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->onlyMethods(array('getRepository'))->getMock();
         $this->entityManager->expects($this->any())->method('getRepository')->will($this->returnValue($this->entityRepository));
 
-        $this->registry = $this->getMockBuilder("Doctrine\Common\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $this->registry = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $this->registry->expects($this->any())->method('getManager')->will($this->returnValue($this->entityManager));
 
-        $this->hetrixtoolsService = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\AzineMailgunHetrixtoolsService")->disableOriginalConstructor()->setMethods(array('checkIpAddressInBlacklist'))->getMock();
+        $this->hetrixtoolsService = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\AzineMailgunHetrixtoolsService")->disableOriginalConstructor()->onlyMethods(array('checkIpAddressInBlacklist'))->getMock();
 
-        $this->azineMailgunService = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Services\AzineMailgunMailerService")->disableOriginalConstructor()->setMethods(array('sendBlacklistNotification'))->getMock();
+        $this->azineMailgunService = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Services\AzineMailgunMailerService")->disableOriginalConstructor()->onlyMethods(array('sendBlacklistNotification'))->getMock();
         $this->azineMailgunService->expects($this->any())->method('sendBlacklistNotification')->will($this->returnvalue(1));
 
         $this->blackListNotificationRepository = $this->getMockBuilder(HetrixToolsBlacklistResponseNotificationRepository::class)->disableOriginalConstructor()->getMock();
@@ -101,7 +101,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester->execute(array(''));
 
         $display = $tester->getDisplay();
-        $this->assertContains(CheckIpAddressIsBlacklistedCommand::BLACKLIST_REPORT_WAS_SENT, $display);
+        $this->assertStringContainsString(CheckIpAddressIsBlacklistedCommand::BLACKLIST_REPORT_WAS_SENT, $display);
     }
 
     public function testSendingBlackListReportNotMutedSent()
@@ -114,7 +114,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester->execute(array(''));
 
         $display = $tester->getDisplay();
-        $this->assertContains(CheckIpAddressIsBlacklistedCommand::BLACKLIST_REPORT_WAS_SENT, $display);
+        $this->assertStringContainsString(CheckIpAddressIsBlacklistedCommand::BLACKLIST_REPORT_WAS_SENT, $display);
     }
 
     public function testSendingBlackListReportLastNotificationIsLongSinceAndListsAreTheSameSent()
@@ -132,7 +132,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester->execute(array(''));
 
         $display = $tester->getDisplay();
-        $this->assertContains(CheckIpAddressIsBlacklistedCommand::BLACKLIST_REPORT_WAS_SENT, $display);
+        $this->assertStringContainsString(CheckIpAddressIsBlacklistedCommand::BLACKLIST_REPORT_WAS_SENT, $display);
     }
 
     public function testSendingBlackListReportLastNotificationIsRecentButListsAreNotTheSameSent()
@@ -168,7 +168,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester->execute(array(''));
 
         $display = $tester->getDisplay();
-        $this->assertContains(CheckIpAddressIsBlacklistedCommand::BLACKLIST_REPORT_WAS_SENT, $display);
+        $this->assertStringContainsString(CheckIpAddressIsBlacklistedCommand::BLACKLIST_REPORT_WAS_SENT, $display);
     }
 
     public function testSendingBlackListReportLastNotificationIsRecentButListsNotChangedMuted()
@@ -186,7 +186,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester->execute(array(''));
 
         $display = $tester->getDisplay();
-        $this->assertContains(CheckIpAddressIsBlacklistedCommand::BLACKLIST_REPORT_IS_SAME_AS_PREVIOUS, $display);
+        $this->assertStringContainsString(CheckIpAddressIsBlacklistedCommand::BLACKLIST_REPORT_IS_SAME_AS_PREVIOUS, $display);
     }
 
     public function testSendingBlackListReportNotListedNotSent()
@@ -202,7 +202,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester->execute(array(''));
 
         $display = $tester->getDisplay();
-        $this->assertContains(CheckIpAddressIsBlacklistedCommand::IP_IS_NOT_BLACKLISTED, $display);
+        $this->assertStringContainsString(CheckIpAddressIsBlacklistedCommand::IP_IS_NOT_BLACKLISTED, $display);
     }
 
     public function testSendingBlackListReportNoResponseShowError()
@@ -213,7 +213,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester->execute(array(''));
 
         $display = $tester->getDisplay();
-        $this->assertContains(CheckIpAddressIsBlacklistedCommand::NO_VALID_RESPONSE_FROM_HETRIX, $display);
+        $this->assertStringContainsString(CheckIpAddressIsBlacklistedCommand::NO_VALID_RESPONSE_FROM_HETRIX, $display);
     }
 
     /**
@@ -222,7 +222,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
     private function getTester($muteDays = 0)
     {
         $application = new Application();
-        $application->add(new CheckIpAddressIsBlacklistedCommand($this->registry, $this->hetrixtoolsService, $this->azineMailgunService, 'test', $muteDays));
+        $application->addCommand(new CheckIpAddressIsBlacklistedCommand($this->registry, $this->hetrixtoolsService, $this->azineMailgunService, 'test', $muteDays));
         $command = $this->getCheckIpAddressIsBlacklistedCommand($application);
         $tester = new CommandTester($command);
 

--- a/Tests/Command/DeleteOldEntriesCommandTest.php
+++ b/Tests/Command/DeleteOldEntriesCommandTest.php
@@ -20,32 +20,32 @@ class DeleteOldEntriesCommandTest extends \PHPUnit\Framework\TestCase
     public function testHelpInfo()
     {
         $application = new Application();
-        $application->add(new DeleteOldEntriesCommand($this->mailgunServiceMock));
+        $application->addCommand(new DeleteOldEntriesCommand($this->mailgunServiceMock));
         $command = $this->getDeleteOldEntriesCommand($application);
 
         $display = $command->getHelp();
-        $this->assertContains('Mailgun accepted the request to send/forward the email and the message has been placed in queue.', $display);
+        $this->assertStringContainsString('Mailgun accepted the request to send/forward the email and the message has been placed in queue.', $display);
     }
 
     public function testDeleteOldEntriesWithoutParams()
     {
         $application = new Application();
-        $application->add(new DeleteOldEntriesCommand($this->mailgunServiceMock));
+        $application->addCommand(new DeleteOldEntriesCommand($this->mailgunServiceMock));
         $command = $this->getDeleteOldEntriesCommand($application);
 
         self::$days = 60;
         self::$count = 14;
         self::$type = null;
-        $this->mailgunServiceMock->expects($this->once())->method('removeEvents')->will($this->returnCallback(array($this, 'removeEventsCallback')));
+        $this->mailgunServiceMock->expects($this->once())->method('removeEvents')->willReturnCallback(array($this, 'removeEventsCallback'));
 
         $tester = new CommandTester($command);
 
         $tester->execute(array(''));
         $display = $tester->getDisplay();
-        $this->assertContains('deleting entries of any type.', $display);
-        $this->assertContains("using default age-limit of '60 days ago'.", $display);
-        $this->assertContains('All MailgunEvents (& their CustomVariables & Attachments) older than', $display);
-        $this->assertContains('of any type have been deleted (14).', $display);
+        $this->assertStringContainsString('deleting entries of any type.', $display);
+        $this->assertStringContainsString("using default age-limit of '60 days ago'.", $display);
+        $this->assertStringContainsString('All MailgunEvents (& their CustomVariables & Attachments) older than', $display);
+        $this->assertStringContainsString('of any type have been deleted (14).', $display);
     }
 
     public static $days;
@@ -74,48 +74,46 @@ class DeleteOldEntriesCommandTest extends \PHPUnit\Framework\TestCase
     public function testDeleteOldEntriesWithDate()
     {
         $application = new Application();
-        $application->add(new DeleteOldEntriesCommand($this->mailgunServiceMock));
+        $application->addCommand(new DeleteOldEntriesCommand($this->mailgunServiceMock));
         $command = $this->getDeleteOldEntriesCommand($application);
 
         self::$days = 21;
         self::$count = 11;
         self::$type = null;
-        $this->mailgunServiceMock->expects($this->once())->method('removeEvents')->will($this->returnCallback(array($this, 'removeEventsCallback')));
+        $this->mailgunServiceMock->expects($this->once())->method('removeEvents')->willReturnCallback(array($this, 'removeEventsCallback'));
 
         $tester = new CommandTester($command);
 
         $tester->execute(array('date' => '21 days ago'));
         $display = $tester->getDisplay();
-        $this->assertContains('deleting entries of any type.', $display);
-        $this->assertContains('All MailgunEvents (& their CustomVariables & Attachments) older than', $display);
-        $this->assertContains('of any type have been deleted (11).', $display);
+        $this->assertStringContainsString('deleting entries of any type.', $display);
+        $this->assertStringContainsString('All MailgunEvents (& their CustomVariables & Attachments) older than', $display);
+        $this->assertStringContainsString('of any type have been deleted (11).', $display);
     }
 
     public function testDeleteOldEntriesWithDateAndType()
     {
         $application = new Application();
-        $application->add(new DeleteOldEntriesCommand($this->mailgunServiceMock));
+        $application->addCommand(new DeleteOldEntriesCommand($this->mailgunServiceMock));
         $command = $this->getDeleteOldEntriesCommand($application);
 
         self::$days = 33;
         self::$count = 77;
         self::$type = 'opened';
-        $this->mailgunServiceMock->expects($this->once())->method('removeEvents')->will($this->returnCallback(array($this, 'removeEventsCallback')));
+        $this->mailgunServiceMock->expects($this->once())->method('removeEvents')->willReturnCallback(array($this, 'removeEventsCallback'));
 
         $tester = new CommandTester($command);
         $tester->execute(array('date' => '33 days ago', 'type' => self::$type));
         $display = $tester->getDisplay();
-        $this->assertContains('All MailgunEvents (& their CustomVariables & Attachments) older than', $display);
-        $this->assertContains("of type '".self::$type."' have been deleted (77).", $display);
+        $this->assertStringContainsString('All MailgunEvents (& their CustomVariables & Attachments) older than', $display);
+        $this->assertStringContainsString("of type '".self::$type."' have been deleted (77).", $display);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testDeleteOldEntriesWithInvalidType()
     {
+        $this->expectException(\Symfony\Component\DependencyInjection\Exception\InvalidArgumentException::class);
         $application = new Application();
-        $application->add(new DeleteOldEntriesCommand($this->mailgunServiceMock));
+        $application->addCommand(new DeleteOldEntriesCommand($this->mailgunServiceMock));
         $command = $this->getDeleteOldEntriesCommand($application);
 
         $tester = new CommandTester($command);

--- a/Tests/Controller/MailgunControllerTest.php
+++ b/Tests/Controller/MailgunControllerTest.php
@@ -57,12 +57,12 @@ class MailgunControllerTest extends WebTestCase
         // if redirected to a login-page, login as admin-user
         if (5 == $crawler->filter('input')->count() && 1 == $crawler->filter('#username')->count() && 1 == $crawler->filter('#password')->count()) {
             // set the password of the admin
-            $userProvider = $this->getContainer()->get('fos_user.user_provider.username_email');
+            $userProvider = $this->getAppContainer()->get('fos_user.user_provider.username_email');
             $user = $userProvider->loadUserByUsername($username);
             $user->setPlainPassword($password);
             $user->addRole('ROLE_ADMIN');
 
-            $userManager = $this->getContainer()->get('fos_user.user_manager');
+            $userManager = $this->getAppContainer()->get('fos_user.user_manager');
             $userManager->updateUser($user);
 
             $crawler = $crawler->filter("input[type='submit']");
@@ -90,7 +90,7 @@ class MailgunControllerTest extends WebTestCase
      *
      * @return \Symfony\Component\DependencyInjection\ContainerInterface
      */
-    private function getContainer()
+    private function getAppContainer()
     {
         if (null == $this->appContainer) {
             $this->appContainer = static::$kernel->getContainer();
@@ -104,7 +104,7 @@ class MailgunControllerTest extends WebTestCase
      */
     private function getRouter()
     {
-        return $this->getContainer()->get('router');
+        return $this->getAppContainer()->get('router');
     }
 
     /**
@@ -112,7 +112,7 @@ class MailgunControllerTest extends WebTestCase
      */
     private function getEntityManager()
     {
-        return $this->getContainer()->get('doctrine.orm.entity_manager');
+        return $this->getAppContainer()->get('doctrine.orm.entity_manager');
     }
 
     /**

--- a/Tests/Controller/MailgunWebhookControllerTest.php
+++ b/Tests/Controller/MailgunWebhookControllerTest.php
@@ -139,7 +139,7 @@ class MailgunWebhookControllerTest extends WebTestCase
     {
         $postData = TestHelper::getPostDataWithoutSignature($newApi);
 
-        $key = $this->getContainer()->getParameter(AzineMailgunWebhooksExtension::PREFIX.'_'.AzineMailgunWebhooksExtension::API_KEY);
+        $key = $this->getAppContainer()->getParameter(AzineMailgunWebhooksExtension::PREFIX.'_'.AzineMailgunWebhooksExtension::API_KEY);
 
         if ($newApi) {
             $postData['signature']['signature'] = hash_hmac('SHA256', $postData['signature']['timestamp'].$postData['signature']['token'], $key);
@@ -174,7 +174,7 @@ class MailgunWebhookControllerTest extends WebTestCase
         $manager = $this->getEntityManager();
         $eventReop = $manager->getRepository("Azine\MailgunWebhooksBundle\Entity\MailgunEvent");
 
-        $apiKey = $this->getContainer()->getParameter(AzineMailgunWebhooksExtension::PREFIX.'_'.AzineMailgunWebhooksExtension::API_KEY);
+        $apiKey = $this->getAppContainer()->getParameter(AzineMailgunWebhooksExtension::PREFIX.'_'.AzineMailgunWebhooksExtension::API_KEY);
 
         // make sure there is plenty of data in the application to be able to verify paging
         if (sizeof($eventReop->findAll()) < 102) {
@@ -245,7 +245,7 @@ class MailgunWebhookControllerTest extends WebTestCase
         $manager = $this->getEntityManager();
         $eventReop = $manager->getRepository("Azine\MailgunWebhooksBundle\Entity\MailgunEvent");
 
-        $apiKey = $this->getContainer()->getParameter(AzineMailgunWebhooksExtension::PREFIX.'_'.AzineMailgunWebhooksExtension::API_KEY);
+        $apiKey = $this->getAppContainer()->getParameter(AzineMailgunWebhooksExtension::PREFIX.'_'.AzineMailgunWebhooksExtension::API_KEY);
 
         // make sure there is data in the application
         $events = $eventReop->findAll();
@@ -254,7 +254,7 @@ class MailgunWebhookControllerTest extends WebTestCase
             $events = $eventReop->findAll();
         }
 
-        $webViewTokenName = $this->getContainer()->getParameter(AzineMailgunWebhooksExtension::PREFIX.'_'.AzineMailgunWebhooksExtension::WEB_VIEW_TOKEN);
+        $webViewTokenName = $this->getAppContainer()->getParameter(AzineMailgunWebhooksExtension::PREFIX.'_'.AzineMailgunWebhooksExtension::WEB_VIEW_TOKEN);
 
         $testTokenValue = 'testValue';
         $messageHeader = array($webViewTokenName => $testTokenValue);
@@ -292,12 +292,12 @@ class MailgunWebhookControllerTest extends WebTestCase
         // if redirected to a login-page, login as admin-user
         if (5 == $crawler->filter('input')->count() && 1 == $crawler->filter('#username')->count() && 1 == $crawler->filter('#password')->count()) {
             // set the password of the admin
-            $userProvider = $this->getContainer()->get('fos_user.user_provider.username_email');
+            $userProvider = $this->getAppContainer()->get('fos_user.user_provider.username_email');
             $user = $userProvider->loadUserByUsername($username);
             $user->setPlainPassword($password);
             $user->addRole('ROLE_ADMIN');
 
-            $userManager = $this->getContainer()->get('fos_user.user_manager');
+            $userManager = $this->getAppContainer()->get('fos_user.user_manager');
             $userManager->updateUser($user);
 
             $crawler = $crawler->filter("input[type='submit']");
@@ -325,7 +325,7 @@ class MailgunWebhookControllerTest extends WebTestCase
      *
      * @return \Symfony\Component\DependencyInjection\ContainerInterface
      */
-    private function getContainer()
+    private function getAppContainer()
     {
         if (null == $this->appContainer) {
             $this->appContainer = static::$kernel->getContainer();
@@ -339,7 +339,7 @@ class MailgunWebhookControllerTest extends WebTestCase
      */
     private function getRouter()
     {
-        return $this->getContainer()->get('router');
+        return $this->getAppContainer()->get('router');
     }
 
     /**
@@ -347,7 +347,7 @@ class MailgunWebhookControllerTest extends WebTestCase
      */
     private function getEntityManager()
     {
-        return $this->getContainer()->get('doctrine.orm.entity_manager');
+        return $this->getAppContainer()->get('doctrine.orm.entity_manager');
     }
 
     /**
@@ -355,7 +355,7 @@ class MailgunWebhookControllerTest extends WebTestCase
      */
     private function getEventDispatcher()
     {
-        return $this->getContainer()->get('event_dispatcher');
+        return $this->getAppContainer()->get('event_dispatcher');
     }
 
     /**

--- a/Tests/Controller/MailgunWebhookControllerTest.php
+++ b/Tests/Controller/MailgunWebhookControllerTest.php
@@ -86,7 +86,7 @@ class MailgunWebhookControllerTest extends WebTestCase
         }
 
         $this->assertSame(401, $client->getResponse()->getStatusCode(), "Response-Code 401 expected for post-data with invalid signature: \n\n$webhookdata\n\n\n");
-        $this->assertContains('Signature verification failed.', $crawler->text(), 'Response expected.');
+        $this->assertStringContainsString('Signature verification failed.', $crawler->text(), 'Response expected.');
         $this->assertSame($count, sizeof($eventReop->findAll()), 'No new db entry for the webhook expected!');
 
         // post valid data to the webhook-url and check the response
@@ -97,7 +97,7 @@ class MailgunWebhookControllerTest extends WebTestCase
             $crawler = $client->request('POST', $url, $validPostData, $attachments);
         }
         $this->assertSame(200, $client->getResponse()->getStatusCode(), "Response-Code 200 expected for '$url'.\n\n$webhookdata\n\n\n".$client->getResponse()->getContent());
-        $this->assertContains('Thanx, for the info.', $crawler->text(), 'Response expected.');
+        $this->assertStringContainsString('Thanx, for the info.', $crawler->text(), 'Response expected.');
         $this->assertSame($count + 1, sizeof($eventReop->findAll()), 'One new db entry for the webhook expected!');
 
         // post valid data to the webhook-url and check the response
@@ -113,7 +113,7 @@ class MailgunWebhookControllerTest extends WebTestCase
             $crawler = $client->request('POST', $url, $validPostData, $attachments);
         }
         $this->assertSame(200, $client->getResponse()->getStatusCode(), "Response-Code 200 expected for '$url'.\n\n$webhookdata\n\n\n".$client->getResponse()->getContent());
-        $this->assertContains('Thanx, for the info.', $crawler->text(), 'Response expected.');
+        $this->assertStringContainsString('Thanx, for the info.', $crawler->text(), 'Response expected.');
 
         // post a complaint event to check if mail is triggered.
         if ($newApi) {
@@ -126,7 +126,7 @@ class MailgunWebhookControllerTest extends WebTestCase
             $crawler = $client->request('POST', $url, $validPostData, $attachments);
         }
         $this->assertSame(200, $client->getResponse()->getStatusCode(), "Response-Code 200 expected for '$url'.\n\n$webhookdata\n\n\n".$client->getResponse()->getContent());
-        $this->assertContains('Thanx, for the info.', $crawler->text(), 'Response expected.');
+        $this->assertStringContainsString('Thanx, for the info.', $crawler->text(), 'Response expected.');
         $this->assertSame($count + 4, sizeof($eventReop->findAll()), 'One new db entry for the webhook expected!');
 
         $mailCollector = $client->getProfile()->getCollector('swiftmailer');

--- a/Tests/Services/AzineMailgunMailerServiceTest.php
+++ b/Tests/Services/AzineMailgunMailerServiceTest.php
@@ -20,18 +20,18 @@ class AzineMailgunMailerServiceTest extends WebTestCase
         $client->followRedirects();
 
         /** @var \Swift_Mailer $mailer */
-        $mailer = $this->getContainer()->get('mailer');
+        $mailer = $this->getAppContainer()->get('mailer');
         /** @var \Twig_Environment $twig */
-        $twig = $this->getContainer()->get('twig');
+        $twig = $this->getAppContainer()->get('twig');
         /** @var Translator $translator */
-        $translator = $this->getContainer()->get('translator');
+        $translator = $this->getAppContainer()->get('translator');
         $fromEmail = 'sender@mail.com';
         $ticketId = '123';
         $ticketSubject = 'test';
         $ticketMessage = 'testMessage';
         $spamAlertsRecipientEmail = 'reciever@mail.com';
         /** @var ManagerRegistry $managerRegistry */
-        $managerRegistry = $this->getContainer()->get('doctrine');
+        $managerRegistry = $this->getAppContainer()->get('doctrine');
         $sendIntervalSeconds = 1;
 
         $mailgunMailerService = new AzineMailgunMailerService($mailer, $twig, $translator,$fromEmail, $ticketId,
@@ -65,7 +65,7 @@ class AzineMailgunMailerServiceTest extends WebTestCase
      *
      * @return \Symfony\Component\DependencyInjection\ContainerInterface
      */
-    private function getContainer()
+    private function getAppContainer()
     {
         if (null == $this->appContainer) {
             $this->appContainer = static::$kernel->getContainer();

--- a/Tests/Services/AzineMailgunServiceTest.php
+++ b/Tests/Services/AzineMailgunServiceTest.php
@@ -26,7 +26,7 @@ class AzineMailgunServiceTest extends \PHPUnit\Framework\TestCase
         $em = $this->getMockBuilder("Doctrine\ORM\EntityManager")->disableOriginalConstructor()->getMock();
         $em->expects($this->once())->method('createQueryBuilder')->will($this->returnValue($qb));
 
-        $registry = $this->getMockBuilder("Doctrine\Common\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $registry = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $registry->expects($this->once())->method('getManager')->will($this->returnValue($em));
 
         $amgs = new AzineMailgunService($registry);
@@ -52,7 +52,7 @@ class AzineMailgunServiceTest extends \PHPUnit\Framework\TestCase
         $em = $this->getMockBuilder("Doctrine\ORM\EntityManager")->disableOriginalConstructor()->getMock();
         $em->expects($this->once())->method('createQueryBuilder')->will($this->returnValue($qb));
 
-        $registry = $this->getMockBuilder("Doctrine\Common\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $registry = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $registry->expects($this->once())->method('getManager')->will($this->returnValue($em));
 
         $amgs = new AzineMailgunService($registry);
@@ -78,7 +78,7 @@ class AzineMailgunServiceTest extends \PHPUnit\Framework\TestCase
         $em = $this->getMockBuilder("Doctrine\ORM\EntityManager")->disableOriginalConstructor()->getMock();
         $em->expects($this->once())->method('createQueryBuilder')->will($this->returnValue($qb));
 
-        $registry = $this->getMockBuilder("Doctrine\Common\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
+        $registry = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
         $registry->expects($this->once())->method('getManager')->will($this->returnValue($em));
 
         $amgs = new AzineMailgunService($registry);

--- a/Tests/Services/HetrixtoolsService/AzineMailgunHetrixtoolsServiceTest.php
+++ b/Tests/Services/HetrixtoolsService/AzineMailgunHetrixtoolsServiceTest.php
@@ -81,7 +81,7 @@ class AzineMailgunHetrixtoolsServiceTest extends \PHPUnit\Framework\TestCase
 
         $hetrixtoolsService = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\AzineMailgunHetrixtoolsService")
             ->setConstructorArgs(array(new NullLogger(), $apiKey, $url))
-            ->setMethods(array('executeCheck'))->getMock();
+            ->onlyMethods(array('executeCheck'))->getMock();
         $hetrixtoolsService->expects($this->once())->method('executeCheck')->will($this->returnValue($this->responseJson));
 
         /** @var AzineMailgunHetrixtoolsService $hetrixtoolsService */

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -99,3 +99,23 @@ class Version20201228090100 extends AbstractMigration implements ContainerAwareI
 }
 
 ```
+
+
+## Upgrade to PHP 8.5 and Symfony 7.4
+
+### Breaking/runtime requirements
+- Minimum PHP version is now **8.5**.
+- Symfony components now require **7.4**.
+- Twig is constrained to **3.x**.
+- Doctrine ORM is constrained to **3.3+** and legacy `doctrine/common` was removed.
+
+### Testing/tooling changes
+- PHPUnit configuration was migrated to a modern schema (`phpunit.xml.dist`).
+- GitHub Actions is configured to run PHPUnit on every push/pull request for:
+  - preferred stable dependencies
+  - lowest supported dependencies
+
+### Manual follow-up checklist for consumers
+1. Run `composer update` in your host application.
+2. Review Doctrine ORM 3 migration notes if your application depends on removed Doctrine APIs.
+3. Run your application test suite and smoke-test webhook ingestion paths.

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,14 @@
 {
     "name": "azine/mailgunwebhooks-bundle",
     "type": "symfony-bundle",
-    "description": "Symfony2 Bundle to easily capture feedback from mailgun.com via their provided webhooks",
-    "keywords": ["Mailgun", "mailgun.com", "transactional email", "email", "webhooks"],
+    "description": "Symfony Bundle to capture feedback from mailgun.com via their provided webhooks",
+    "keywords": [
+        "Mailgun",
+        "mailgun.com",
+        "transactional email",
+        "email",
+        "webhooks"
+    ],
     "homepage": "https://github.com/azine/AzineMailgunWebhooksBundle.git",
     "license": "MIT",
     "authors": [
@@ -13,33 +19,45 @@
     ],
     "config": {
         "process-timeout": 590,
-        "github-protocols": ["https", "git", "ssh"],
-        "github-domains": ["github.com"]
+        "sort-packages": true,
+        "preferred-install": {
+            "*": "dist"
         },
+        "allow-plugins": {
+            "symfony/flex": true
+        }
+    },
     "require": {
-        "php": ">=7.0",
+        "php": "^8.5",
         "ext-mailparse": "*",
-        "symfony/framework-bundle": "^4.0|^5.4|^6.3",
-        "symfony/config": "^4.0|^5.4|^6.3",
-        "symfony/console": "^4.0|^5.4|^6.3",
-        "symfony/dependency-injection": "^4.0|^5.4|^6.3",
-        "symfony/dom-crawler": "^4.0|^5.4|^6.3",
-        "symfony/event-dispatcher": "^4.0|^5.4|^6.3",
-        "symfony/http-foundation": "^4.0|^5.4|^6.3",
-        "symfony/http-kernel": ">=4.4.50,^4.0|^5.4",
-        "symfony/yaml": "^4.0|^5.4|^6.3",
-        "symfony/process": "^4.0|^5.4|^6.3",
-        "symfony/routing": "^4.0|^5.4|^6.3",
-        "symfony/translation": "^4.0|^5.4|^6.3",
-        "twig/twig": ">=1.34,^1.0|^2.0|^3.0 ",
-        "doctrine/orm": "~2.2,>=2.2.3",
-        "doctrine/common": "~2.2,>=2.2.3"
+        "doctrine/orm": "^3.3",
+        "symfony/config": "^7.4",
+        "symfony/console": "^7.4",
+        "symfony/dependency-injection": "^7.4",
+        "symfony/dom-crawler": "^7.4",
+        "symfony/event-dispatcher": "^7.4",
+        "symfony/framework-bundle": "^7.4",
+        "symfony/http-foundation": "^7.4",
+        "symfony/http-kernel": "^7.4",
+        "symfony/process": "^7.4",
+        "symfony/routing": "^7.4",
+        "symfony/translation": "^7.4",
+        "symfony/yaml": "^7.4",
+        "twig/twig": "^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit":  "^6.0|^7.0|^8.0"
+        "phpunit/phpunit": "^12.0"
     },
     "autoload": {
-        "psr-4": { "Azine\\MailgunWebhooksBundle\\": "src/" }
+        "psr-4": {
+            "Azine\\MailgunWebhooksBundle\\": "src/"
+        }
     },
-    "minimum-stability": "dev"
+    "autoload-dev": {
+        "psr-4": {
+            "Azine\\MailgunWebhooksBundle\\Tests\\": "Tests/"
+        }
+    },
+    "minimum-stability": "stable",
+    "prefer-stable": true
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,19 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/12.2/phpunit.xsd"
          bootstrap="Tests/bootstrap.php"
-	>
+         cacheDirectory=".phpunit.cache"
+         colors="true"
+         stopOnFailure="false">
 
     <php>
-        <env name="KERNEL_CLASS" value="AppKernel" />
-        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak"/>
     </php>
 
     <testsuites>
@@ -22,16 +16,13 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true"
-                   addUncoveredFilesFromWhitelist="false">
+    <coverage includeUncoveredFiles="false">
+        <include>
             <directory suffix=".php">src/Command</directory>
             <directory suffix=".php">src/Controller</directory>
             <directory suffix=".php">src/DependencyInjection</directory>
             <directory suffix=".php">src/Entity</directory>
             <directory suffix=".php">src/Services</directory>
-            <!-- <exclude>
-            </exclude> -->
-        </whitelist>
-    </filter>
+        </include>
+    </coverage>
 </phpunit>

--- a/src/Command/DeleteOldEntriesCommand.php
+++ b/src/Command/DeleteOldEntriesCommand.php
@@ -30,7 +30,7 @@ class DeleteOldEntriesCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setName(static::$defaultName)
             ->setDescription('Delete old mailgun events from the database')
@@ -66,22 +66,22 @@ EOF
             ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $type = $input->getArgument('type');
         $ageLimit = $input->getArgument('date');
 
         if (null == $type || '' == $type) {
-            $output->write('deleting entries of any type.', true);
+            $output->writeln('deleting entries of any type.');
             $typeDesc = 'any type';
-        } elseif (array_search($type, array('accepted', 'rejected', 'delivered', 'failed', 'opened', 'clicked', 'unsubscribed', 'complained', 'stored', 'dropped'))) {
+        } elseif (in_array($type, array('accepted', 'rejected', 'delivered', 'failed', 'opened', 'clicked', 'unsubscribed', 'complained', 'stored', 'dropped'), true)) {
             $typeDesc = "type '$type'";
         } else {
             throw new InvalidArgumentException("Unknown type: $type");
         }
 
         if (null == $ageLimit || '' == $ageLimit) {
-            $output->write("using default age-limit of '60 days ago'.", true);
+            $output->writeln("using default age-limit of '60 days ago'.");
             $ageLimit = '60 days ago';
         }
 
@@ -89,7 +89,7 @@ EOF
 
         $result = $this->mailgunService->removeEvents($type, $date);
 
-        $output->write('All MailgunEvents (& their CustomVariables & Attachments) older than '.$date->format('Y-m-d H:i:s')." of $typeDesc have been deleted ($result).", true);
+        $output->writeln('All MailgunEvents (& their CustomVariables & Attachments) older than '.$date->format('Y-m-d H:i:s')." of $typeDesc have been deleted ($result).");
 
         return 0;
     }

--- a/src/Services/AzineMailgunService.php
+++ b/src/Services/AzineMailgunService.php
@@ -55,7 +55,7 @@ class AzineMailgunService
      *
      * @return int number of deleted records
      */
-    public function removeEvents($type = null, \DateTime $ageLimit)
+    public function removeEvents($type, \DateTime $ageLimit)
     {
         $qb = $this->getManager()->createQueryBuilder()->delete("Azine\MailgunWebhooksBundle\Entity\MailgunEvent", 'e')->andWhere('e.timestamp < :age')
                 ->setParameter('age', $ageLimit->getTimestamp());


### PR DESCRIPTION
### Motivation
- Bring the package up to modern PHP/Symfony versions and developer tooling by requiring PHP 8.5 and Symfony 7.4-level components.
- Modernize test tooling and CI so tests run on GitHub Actions with stable and lowest dependency matrices and use a current PHPUnit schema.
- Improve composer metadata and autoloading for clearer packaging and developer workflows.

### Description
- Updated `composer.json` to require `php:^8.5`, Symfony `^7.4` components, `doctrine/orm:^3.3`, `twig:^3.0`, and bumped `phpunit/phpunit` to `^12.0`, plus added `autoload-dev` and packaging config tweaks. 
- Added a GitHub Actions workflow at `.github/workflows/phpunit.yml` that validates composer, caches dependencies, installs stable/lowest deps and runs `vendor/bin/phpunit -c phpunit.xml.dist` on PHP 8.5. 
- Modernized `phpunit.xml.dist` to the PHPUnit 12 schema, enabled cache directory, adjusted coverage configuration, and set bootstrap to `Tests/bootstrap.php`. 
- Simplified `.travis.yml` to act as legacy CI with PHP 8.5 and a simple `vendor/bin/phpunit -c phpunit.xml.dist` script, and updated `README.md` and `UPGRADE.md` with new requirements and migration notes. 

### Testing
- No automated test runs are included in this PR itself; CI is configured to run PHPUnit via GitHub Actions using `vendor/bin/phpunit -c phpunit.xml.dist` for both `stable` and `lowest` dependency modes on PHP 8.5. 
- The legacy Travis job was adjusted to run the same PHPUnit command for backward compatibility but no Travis run results are included here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1006a9a674832394dcbfe4d929f39a)