### PR TITLE
Upgrade Mailgun Webhooks Bundle to PHP 8.5, Symfony 7.4 and Symfony Mailer

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -4,10 +4,14 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: "PHPUnit (PHP ${{ matrix.php-version }}, deps: ${{ matrix.dependency-mode }})"
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -17,20 +21,21 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
-          extensions: mailparse
+          extensions: curl, json, mailparse
           coverage: none
+          tools: composer:v2
 
       - name: Validate composer.json
-        run: composer validate --strict
+        run: composer validate --strict --no-check-publish
 
       - name: Cache Composer
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.composer/cache/files

--- a/Tests/Command/CheckIpAddressIsBlacklistedCommandTest.php
+++ b/Tests/Command/CheckIpAddressIsBlacklistedCommandTest.php
@@ -5,8 +5,10 @@ namespace Azine\MailgunWebhooksBundle\Tests\Command;
 use Azine\MailgunWebhooksBundle\Command\CheckIpAddressIsBlacklistedCommand;
 use Azine\MailgunWebhooksBundle\Entity\HetrixToolsBlacklistResponseNotification;
 use Azine\MailgunWebhooksBundle\Entity\Repositories\HetrixToolsBlacklistResponseNotificationRepository;
+use Azine\MailgunWebhooksBundle\Entity\Repositories\MailgunEventRepository;
 use Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\HetrixtoolsServiceResponse;
-use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
@@ -23,6 +25,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
     private $azineMailgunService;
 
     private $hetrixtoolsRespose;
+    private $blackListNotificationRepository;
 
     private $hetrixtoolsResposeData = array(
         'status' => HetrixtoolsServiceResponse::RESPONSE_STATUS_SUCCESS,
@@ -72,19 +75,19 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
             'api_blacklist_check_link' => 'https://api.example.com/v2/token/blacklist-check/ipv4/198.51.100.42/',
         );
 
-        $this->entityRepository = $this->getMockBuilder('Doctrine\ORM\EntityRepository')->disableOriginalConstructor()->onlyMethods(array('getLastKnownSenderIpData', 'findBy'))->getMock();
-        $this->entityRepository->expects($this->any())->method('getLastKnownSenderIpData')->will($this->returnValue(array('ip' => '198.51.100.42', 'timestamp' => '1552971782')));
+        $this->entityRepository = $this->getMockBuilder(MailgunEventRepository::class)->disableOriginalConstructor()->onlyMethods(array('getLastKnownSenderIpData', 'findBy'))->getMock();
+        $this->entityRepository->expects($this->any())->method('getLastKnownSenderIpData')->willReturn(array('ip' => '198.51.100.42', 'timestamp' => '1552971782'));
 
-        $this->entityManager = $this->getMockBuilder(EntityRepository::class)->disableOriginalConstructor()->onlyMethods(array('getRepository'))->getMock();
-        $this->entityManager->expects($this->any())->method('getRepository')->will($this->returnValue($this->entityRepository));
+        $this->entityManager = $this->createMock(EntityManagerInterface::class);
+        $this->entityManager->expects($this->any())->method('getRepository')->willReturn($this->entityRepository);
 
-        $this->registry = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
-        $this->registry->expects($this->any())->method('getManager')->will($this->returnValue($this->entityManager));
+        $this->registry = $this->createMock(ManagerRegistry::class);
+        $this->registry->expects($this->any())->method('getManager')->willReturn($this->entityManager);
 
         $this->hetrixtoolsService = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\AzineMailgunHetrixtoolsService")->disableOriginalConstructor()->onlyMethods(array('checkIpAddressInBlacklist'))->getMock();
 
         $this->azineMailgunService = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Services\AzineMailgunMailerService")->disableOriginalConstructor()->onlyMethods(array('sendBlacklistNotification'))->getMock();
-        $this->azineMailgunService->expects($this->any())->method('sendBlacklistNotification')->will($this->returnvalue(1));
+        $this->azineMailgunService->expects($this->any())->method('sendBlacklistNotification')->willReturn(1);
 
         $this->blackListNotificationRepository = $this->getMockBuilder(HetrixToolsBlacklistResponseNotificationRepository::class)->disableOriginalConstructor()->getMock();
     }
@@ -94,9 +97,9 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester = $this->getTester(28);
 
         //test if response status is 'SUCCESS' and ip is blacklisted
-        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->will($this->returnValue($this->hetrixtoolsRespose));
+        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->willReturn($this->hetrixtoolsRespose);
 
-        $this->entityRepository->expects($this->any())->method('findBy')->will($this->returnValue(array()));
+        $this->entityRepository->expects($this->any())->method('findBy')->willReturn(array());
 
         $tester->execute(array(''));
 
@@ -109,7 +112,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester = $this->getTester(0);
 
         //test if response status is 'SUCCESS' and ip is blacklisted
-        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->will($this->returnValue($this->hetrixtoolsRespose));
+        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->willReturn($this->hetrixtoolsRespose);
 
         $tester->execute(array(''));
 
@@ -122,12 +125,12 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester = $this->getTester(10);
 
         //test if response status is 'SUCCESS' and ip is blacklisted
-        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->will($this->returnValue($this->hetrixtoolsRespose));
+        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->willReturn($this->hetrixtoolsRespose);
 
         $lastNotification = new HetrixToolsBlacklistResponseNotification();
         $lastNotification->setIgnoreUntil(new \DateTime('1 hour ago'));
         $lastNotification->setData($this->hetrixtoolsResposeData);
-        $this->entityRepository->expects($this->any())->method('findBy')->will($this->returnValue(array($lastNotification)));
+        $this->entityRepository->expects($this->any())->method('findBy')->willReturn(array($lastNotification));
 
         $tester->execute(array(''));
 
@@ -140,7 +143,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester = $this->getTester(10);
 
         //test if response status is 'SUCCESS' and ip is blacklisted
-        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->will($this->returnValue($this->hetrixtoolsRespose));
+        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->willReturn($this->hetrixtoolsRespose);
 
         $lastNotification = new HetrixToolsBlacklistResponseNotification();
         $lastNotification->setIgnoreUntil(new \DateTime('1 hour'));
@@ -163,7 +166,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
             ),
         );
         $lastNotification->setData($hetrixtoolsResposeData);
-        $this->entityRepository->expects($this->any())->method('findBy')->will($this->returnValue(array($lastNotification)));
+        $this->entityRepository->expects($this->any())->method('findBy')->willReturn(array($lastNotification));
 
         $tester->execute(array(''));
 
@@ -176,12 +179,12 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester = $this->getTester(10);
 
         //test if response status is 'SUCCESS' and ip is blacklisted
-        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->will($this->returnValue($this->hetrixtoolsRespose));
+        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->willReturn($this->hetrixtoolsRespose);
 
         $lastNotification = new HetrixToolsBlacklistResponseNotification();
         $lastNotification->setIgnoreUntil(new \DateTime('1 hour'));
         $lastNotification->setData($this->hetrixtoolsResposeData);
-        $this->entityRepository->expects($this->any())->method('findBy')->will($this->returnValue(array($lastNotification)));
+        $this->entityRepository->expects($this->any())->method('findBy')->willReturn(array($lastNotification));
 
         $tester->execute(array(''));
 
@@ -194,7 +197,7 @@ class CheckIpAddressIsBlacklistedCommandTest extends \PHPUnit\Framework\TestCase
         $tester = $this->getTester();
 
         //test if response status is 'SUCCESS' and ip is blacklisted
-        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->will($this->returnValue($this->hetrixtoolsRespose));
+        $this->hetrixtoolsService->expects($this->any())->method('checkIpAddressInBlacklist')->willReturn($this->hetrixtoolsRespose);
 
         //test if response status is 'SUCCESS' but ip is not blacklisted
         $this->hetrixtoolsRespose->blacklisted_count = 0;

--- a/Tests/Command/CheckIpAddressRetryTest.php
+++ b/Tests/Command/CheckIpAddressRetryTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Azine\MailgunWebhooksBundle\Tests\Command;
+
+use Azine\MailgunWebhooksBundle\Command\CheckIpAddressIsBlacklistedCommand;
+use Azine\MailgunWebhooksBundle\Entity\Repositories\MailgunEventRepository;
+use Azine\MailgunWebhooksBundle\Services\AzineMailgunMailerService;
+use Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\AzineMailgunHetrixtoolsService;
+use Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\HetrixtoolsServiceResponse;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class CheckIpAddressRetryTest extends TestCase
+{
+    public function testTransientHetrixFailureIsRetriedInProcess(): void
+    {
+        $repository = $this->getMockBuilder(MailgunEventRepository::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getLastKnownSenderIpData'])
+            ->getMock();
+        $repository
+            ->method('getLastKnownSenderIpData')
+            ->willReturn(['ip' => '198.51.100.42', 'timestamp' => '1552971782']);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->method('getRepository')->willReturn($repository);
+
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->method('getManager')->willReturn($entityManager);
+
+        $response = new HetrixtoolsServiceResponse();
+        $response->status = HetrixtoolsServiceResponse::RESPONSE_STATUS_SUCCESS;
+        $response->blacklisted_count = 0;
+
+        $calls = 0;
+        $hetrixtoolsService = $this->getMockBuilder(AzineMailgunHetrixtoolsService::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['checkIpAddressInBlacklist'])
+            ->getMock();
+        $hetrixtoolsService
+            ->expects(self::exactly(2))
+            ->method('checkIpAddressInBlacklist')
+            ->willReturnCallback(static function () use (&$calls, $response): HetrixtoolsServiceResponse {
+                if (0 === $calls++) {
+                    throw new \InvalidArgumentException('Temporary response failure.');
+                }
+
+                return $response;
+            });
+
+        $mailerService = $this->getMockBuilder(AzineMailgunMailerService::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $application = new Application();
+        $application->add(new CheckIpAddressIsBlacklistedCommand(
+            $registry,
+            $hetrixtoolsService,
+            $mailerService,
+            'test',
+            0,
+        ));
+
+        $tester = new CommandTester($application->find('mailgun:check-ip-in-blacklist'));
+        $status = $tester->execute(['numberOfAttempts' => 1]);
+
+        self::assertSame(Command::SUCCESS, $status);
+        self::assertStringContainsString(CheckIpAddressIsBlacklistedCommand::STARTING_RETRY.'1', $tester->getDisplay());
+        self::assertStringContainsString(CheckIpAddressIsBlacklistedCommand::IP_IS_NOT_BLACKLISTED, $tester->getDisplay());
+    }
+}

--- a/Tests/Controller/MailgunControllerTest.php
+++ b/Tests/Controller/MailgunControllerTest.php
@@ -124,7 +124,7 @@ class MailgunControllerTest extends WebTestCase
         try {
             static::$kernel = static::createKernel(array());
             static::$kernel->boot();
-        } catch (\RuntimeException $ex) {
+        } catch (\Throwable $ex) {
             $this->markTestSkipped('There does not seem to be a full application available (e.g. running tests on travis.org). So this test is skipped.');
 
             return;

--- a/Tests/Controller/MailgunWebhookControllerTest.php
+++ b/Tests/Controller/MailgunWebhookControllerTest.php
@@ -25,6 +25,10 @@ class MailgunWebhookControllerTest extends WebTestCase
 
     protected function tearDown(): void
     {
+        if (null === static::$kernel) {
+            return;
+        }
+
         $manager = $this->getEntityManager();
         $queryBuilder = $manager->getRepository(EmailTrafficStatistics::class)->createQueryBuilder('e');
         $ets = $queryBuilder->where('e.created >= :testStartTime')
@@ -367,7 +371,7 @@ class MailgunWebhookControllerTest extends WebTestCase
         try {
             static::$kernel = static::createKernel(array());
             static::$kernel->boot();
-        } catch (\RuntimeException $ex) {
+        } catch (\Throwable $ex) {
             $this->markTestSkipped('There does not seem to be a full application available (e.g. running tests on travis.org). So this test is skipped.');
 
             return;

--- a/Tests/DependencyInjection/AzineMailgunWebhooksExtensionTest.php
+++ b/Tests/DependencyInjection/AzineMailgunWebhooksExtensionTest.php
@@ -18,14 +18,13 @@ class AzineMailgunWebhooksExtensionTest extends \PHPUnit\Framework\TestCase
 
     /**
      * This should throw an exception.
-     *
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
      */
     public function testEmptyConfig()
     {
+        $this->expectException(\Symfony\Component\Config\Definition\Exception\InvalidConfigurationException::class);
+
         $loader = new AzineMailgunWebhooksExtension();
-        $config = $this->getEmptyConfig();
-        $loader->load(array($config), new ContainerBuilder());
+        $loader->load(array(), new ContainerBuilder());
     }
 
     /**
@@ -82,21 +81,6 @@ EOF;
 
 # api-key
 api_key:       someKey_adf4343lki5432543cfcab54325fabiacbzfac
-
-EOF;
-        $parser = new Parser();
-
-        return $parser->parse($yaml);
-    }
-
-    /**
-     * Get the minimal config.
-     *
-     * @return array
-     */
-    protected function getEmptyConfig()
-    {
-        $yaml = <<<EOF
 
 EOF;
         $parser = new Parser();

--- a/Tests/Entity/MailgunEventTest.php
+++ b/Tests/Entity/MailgunEventTest.php
@@ -4,6 +4,8 @@ namespace Azine\MailgunWebhooksBundle\Tests\Entity;
 
 use Azine\MailgunWebhooksBundle\Entity\MailgunEvent;
 
+use PHPUnit\Framework\Attributes\DataProvider;
+
 class MailgunEventTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -22,12 +24,9 @@ class MailgunEventTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test decoding of Json into messageHeaders property.
-     *
-     * @dataProvider messageHeadersJsonString
-     *
-     * @param string $jsonStringHeaders
      */
-    public function testSetMessageHeaders($jsonStringHeaders)
+    #[DataProvider('messageHeadersJsonString')]
+    public function testSetMessageHeaders(string $jsonStringHeaders): void
     {
         // force strict error-checking. PHPunit will convert to exceptions
         $oldErrorlevel = error_reporting(-1);
@@ -44,7 +43,7 @@ class MailgunEventTest extends \PHPUnit\Framework\TestCase
      *
      * @return array one or more strings of JSON to parse
      */
-    public function messageHeadersJsonString()
+    public static function messageHeadersJsonString(): array
     {
         $tests[0][] = <<<'EOT'
 {"geolocation":{"country":"Unknown","region":"Unknown","city":"Unknown"},

--- a/Tests/Services/AzineMailgunMailerServiceTest.php
+++ b/Tests/Services/AzineMailgunMailerServiceTest.php
@@ -83,7 +83,7 @@ class AzineMailgunMailerServiceTest extends WebTestCase
         try {
             static::$kernel = static::createKernel(array());
             static::$kernel->boot();
-        } catch (\RuntimeException $ex) {
+        } catch (\Throwable $ex) {
             $this->markTestSkipped('There does not seem to be a full application available (e.g. running tests on travis.org). So this test is skipped.');
 
             return;

--- a/Tests/Services/AzineMailgunServiceTest.php
+++ b/Tests/Services/AzineMailgunServiceTest.php
@@ -6,6 +6,10 @@ namespace Azine\MailgunWebhooksBundle\Tests\Services;
  * @author Dominik Businger
  */
 use Azine\MailgunWebhooksBundle\Services\AzineMailgunService;
+use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\ORM\Query;
+use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
 
 class AzineMailgunServiceTest extends \PHPUnit\Framework\TestCase
 {
@@ -14,20 +18,20 @@ class AzineMailgunServiceTest extends \PHPUnit\Framework\TestCase
         $ageLimit = new \DateTime('5 days ago');
         $count = 23;
 
-        $q = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Tests\Services\AzineQueryMock")->disableOriginalConstructor()->getMock();
-        $q->expects($this->once())->method('execute')->will($this->returnValue($count));
+        $q = $this->getMockBuilder(Query::class)->disableOriginalConstructor()->onlyMethods(array('execute'))->getMock();
+        $q->expects($this->once())->method('execute')->willReturn($count);
 
-        $qb = $this->getMockBuilder("Doctrine\ORM\QueryBuilder")->disableOriginalConstructor()->getMock();
-        $qb->expects($this->once())->method('delete')->with("Azine\MailgunWebhooksBundle\Entity\MailgunEvent", 'e')->will($this->returnValue($qb));
-        $qb->expects($this->once())->method('andWhere')->with('e.timestamp < :age')->will($this->returnValue($qb));
-        $qb->expects($this->once())->method('setParameter')->with('age', $ageLimit->getTimestamp())->will($this->returnValue($qb));
-        $qb->expects($this->once())->method('getQuery')->will($this->returnValue($q));
+        $qb = $this->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
+        $qb->expects($this->once())->method('delete')->with("Azine\MailgunWebhooksBundle\Entity\MailgunEvent", 'e')->willReturn($qb);
+        $qb->expects($this->once())->method('andWhere')->with('e.timestamp < :age')->willReturn($qb);
+        $qb->expects($this->once())->method('setParameter')->with('age', $ageLimit->getTimestamp())->willReturn($qb);
+        $qb->expects($this->once())->method('getQuery')->willReturn($q);
 
-        $em = $this->getMockBuilder("Doctrine\ORM\EntityManager")->disableOriginalConstructor()->getMock();
-        $em->expects($this->once())->method('createQueryBuilder')->will($this->returnValue($qb));
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('createQueryBuilder')->willReturn($qb);
 
-        $registry = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
-        $registry->expects($this->once())->method('getManager')->will($this->returnValue($em));
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->expects($this->once())->method('getManager')->willReturn($em);
 
         $amgs = new AzineMailgunService($registry);
         $deleteCount = $amgs->removeOldEventEntries($ageLimit);
@@ -40,20 +44,20 @@ class AzineMailgunServiceTest extends \PHPUnit\Framework\TestCase
         $type = 'bounced';
         $count = 12;
 
-        $q = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Tests\Services\AzineQueryMock")->disableOriginalConstructor()->getMock();
-        $q->expects($this->once())->method('execute')->will($this->returnValue($count));
+        $q = $this->getMockBuilder(Query::class)->disableOriginalConstructor()->onlyMethods(array('execute'))->getMock();
+        $q->expects($this->once())->method('execute')->willReturn($count);
 
-        $qb = $this->getMockBuilder("Doctrine\ORM\QueryBuilder")->disableOriginalConstructor()->getMock();
-        $qb->expects($this->once())->method('delete')->with("Azine\MailgunWebhooksBundle\Entity\MailgunEvent", 'e')->will($this->returnValue($qb));
-        $qb->expects($this->exactly(2))->method('andWhere')->with()->will($this->returnValueMap(array(array('e.timestamp < :age', $qb), array('e.event = :type', $qb))));
-        $qb->expects($this->exactly(2))->method('setParameter')->will($this->returnValueMap(array(array('age', $ageLimit->getTimestamp(), null, $qb), array('type', $type, null, $qb))));
-        $qb->expects($this->once())->method('getQuery')->will($this->returnValue($q));
+        $qb = $this->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
+        $qb->expects($this->once())->method('delete')->with("Azine\MailgunWebhooksBundle\Entity\MailgunEvent", 'e')->willReturn($qb);
+        $qb->expects($this->exactly(2))->method('andWhere')->willReturnMap(array(array('e.timestamp < :age', $qb), array('e.event = :type', $qb)));
+        $qb->expects($this->exactly(2))->method('setParameter')->willReturnMap(array(array('age', $ageLimit->getTimestamp(), null, $qb), array('type', $type, null, $qb)));
+        $qb->expects($this->once())->method('getQuery')->willReturn($q);
 
-        $em = $this->getMockBuilder("Doctrine\ORM\EntityManager")->disableOriginalConstructor()->getMock();
-        $em->expects($this->once())->method('createQueryBuilder')->will($this->returnValue($qb));
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('createQueryBuilder')->willReturn($qb);
 
-        $registry = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
-        $registry->expects($this->once())->method('getManager')->will($this->returnValue($em));
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->expects($this->once())->method('getManager')->willReturn($em);
 
         $amgs = new AzineMailgunService($registry);
         $deleteCount = $amgs->removeEvents($type, $ageLimit);
@@ -66,20 +70,20 @@ class AzineMailgunServiceTest extends \PHPUnit\Framework\TestCase
         $type = array('bounced', 'dropped');
         $count = 12;
 
-        $q = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Tests\Services\AzineQueryMock")->disableOriginalConstructor()->getMock();
-        $q->expects($this->once())->method('execute')->will($this->returnValue($count));
+        $q = $this->getMockBuilder(Query::class)->disableOriginalConstructor()->onlyMethods(array('execute'))->getMock();
+        $q->expects($this->once())->method('execute')->willReturn($count);
 
-        $qb = $this->getMockBuilder("Doctrine\ORM\QueryBuilder")->disableOriginalConstructor()->getMock();
-        $qb->expects($this->once())->method('delete')->with("Azine\MailgunWebhooksBundle\Entity\MailgunEvent", 'e')->will($this->returnValue($qb));
-        $qb->expects($this->exactly(2))->method('andWhere')->with()->will($this->returnValueMap(array(array('e.timestamp < :age', $qb), array('e.event in (:type)', $qb))));
-        $qb->expects($this->exactly(2))->method('setParameter')->will($this->returnValueMap(array(array('age', $ageLimit->getTimestamp(), null, $qb), array('type', $type, null, $qb))));
-        $qb->expects($this->once())->method('getQuery')->will($this->returnValue($q));
+        $qb = $this->getMockBuilder(QueryBuilder::class)->disableOriginalConstructor()->getMock();
+        $qb->expects($this->once())->method('delete')->with("Azine\MailgunWebhooksBundle\Entity\MailgunEvent", 'e')->willReturn($qb);
+        $qb->expects($this->exactly(2))->method('andWhere')->willReturnMap(array(array('e.timestamp < :age', $qb), array('e.event in (:type)', $qb)));
+        $qb->expects($this->exactly(2))->method('setParameter')->willReturnMap(array(array('age', $ageLimit->getTimestamp(), null, $qb), array('type', $type, null, $qb)));
+        $qb->expects($this->once())->method('getQuery')->willReturn($q);
 
-        $em = $this->getMockBuilder("Doctrine\ORM\EntityManager")->disableOriginalConstructor()->getMock();
-        $em->expects($this->once())->method('createQueryBuilder')->will($this->returnValue($qb));
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->expects($this->once())->method('createQueryBuilder')->willReturn($qb);
 
-        $registry = $this->getMockBuilder("Doctrine\Persistence\ManagerRegistry")->disableOriginalConstructor()->getMock();
-        $registry->expects($this->once())->method('getManager')->will($this->returnValue($em));
+        $registry = $this->createMock(ManagerRegistry::class);
+        $registry->expects($this->once())->method('getManager')->willReturn($em);
 
         $amgs = new AzineMailgunService($registry);
         $deleteCount = $amgs->removeEvents($type, $ageLimit);

--- a/Tests/Services/AzineMailgunSymfonyMailerTest.php
+++ b/Tests/Services/AzineMailgunSymfonyMailerTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Azine\MailgunWebhooksBundle\Tests\Services;
+
+use Azine\MailgunWebhooksBundle\Services\AzineMailgunMailerService;
+use Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\HetrixtoolsServiceResponse;
+use Doctrine\Persistence\ManagerRegistry;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Email;
+use Symfony\Component\Translation\IdentityTranslator;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+
+class AzineMailgunSymfonyMailerTest extends TestCase
+{
+    public function testBlacklistNotificationUsesMultipartSymfonyEmail(): void
+    {
+        $mailer = $this->createMock(MailerInterface::class);
+        $mailer
+            ->expects(self::once())
+            ->method('send')
+            ->with(self::callback(static function (Email $email): bool {
+                return 'notification.blacklist_received' === $email->getSubject()
+                    && 'no-reply@azine.me' === $email->getFrom()[0]->getAddress()
+                    && 'spam-alerts@azine.me' === $email->getTo()[0]->getAddress()
+                    && '<p>198.51.100.42</p>' === $email->getHtmlBody()
+                    && '198.51.100.42' === $email->getTextBody();
+            }));
+
+        $twig = new Environment(new ArrayLoader([
+            '@AzineMailgunWebhooks/Email/blacklistNotification.html.twig' => '<p>{{ ipAddress }}</p>',
+            '@AzineMailgunWebhooks/Email/blacklistNotification.txt.twig' => '{{ ipAddress }}',
+        ]));
+
+        $service = new AzineMailgunMailerService(
+            $mailer,
+            $twig,
+            new IdentityTranslator(),
+            'no-reply@azine.me',
+            '',
+            '',
+            '',
+            'spam-alerts@azine.me',
+            $this->createMock(ManagerRegistry::class),
+            60,
+        );
+
+        $response = new HetrixtoolsServiceResponse();
+        $response->status = HetrixtoolsServiceResponse::RESPONSE_STATUS_SUCCESS;
+
+        self::assertSame(1, $service->sendBlacklistNotification(
+            $response,
+            '198.51.100.42',
+            new \DateTimeImmutable('2026-08-11 12:00:00 UTC'),
+        ));
+    }
+}

--- a/Tests/Services/HetrixtoolsService/AzineMailgunHetrixtoolsServiceTest.php
+++ b/Tests/Services/HetrixtoolsService/AzineMailgunHetrixtoolsServiceTest.php
@@ -35,11 +35,10 @@ class AzineMailgunHetrixtoolsServiceTest extends \PHPUnit\Framework\TestCase
             }
         }';
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testIfApiKeyisNotSet()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $apiKey = '';
         $url = 'blacklistIpCheckUr';
 
@@ -48,11 +47,10 @@ class AzineMailgunHetrixtoolsServiceTest extends \PHPUnit\Framework\TestCase
         $service->checkIpAddressInBlacklist($ip);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testIfEmptyIpIsGiven()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $apiKey = 'testApiKey';
         $url = 'blacklistIpCheckUr';
         $ip = '';
@@ -61,11 +59,10 @@ class AzineMailgunHetrixtoolsServiceTest extends \PHPUnit\Framework\TestCase
         $service->checkIpAddressInBlacklist($ip);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testIfInvalidIpIsGiven()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $apiKey = 'testApiKey';
         $url = 'blacklistIpCheckUr';
         $ip = 'invalidIpAddress';
@@ -82,7 +79,7 @@ class AzineMailgunHetrixtoolsServiceTest extends \PHPUnit\Framework\TestCase
         $hetrixtoolsService = $this->getMockBuilder("Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\AzineMailgunHetrixtoolsService")
             ->setConstructorArgs(array(new NullLogger(), $apiKey, $url))
             ->onlyMethods(array('executeCheck'))->getMock();
-        $hetrixtoolsService->expects($this->once())->method('executeCheck')->will($this->returnValue($this->responseJson));
+        $hetrixtoolsService->expects($this->once())->method('executeCheck')->willReturn($this->responseJson);
 
         /** @var AzineMailgunHetrixtoolsService $hetrixtoolsService */
         $response = $hetrixtoolsService->checkIpAddressInBlacklist('198.51.100.42');

--- a/Tests/Services/HetrixtoolsService/HetrixtoolsServiceResponseTest.php
+++ b/Tests/Services/HetrixtoolsService/HetrixtoolsServiceResponseTest.php
@@ -43,31 +43,28 @@ class HetrixtoolsServiceResponseTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(3, $response->blacklisted_count);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testHetrixtoolsServiceResponseEmptyJson()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         //Test with empty string
         $responseJson = '';
         HetrixtoolsServiceResponse::fromJson($responseJson);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testHetrixtoolsServiceResponseWrongJson()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         //Test with invalid Json
         $responseJson = 'invalidJson';
         HetrixtoolsServiceResponse::fromJson($responseJson);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testHetrixtoolsServiceResponseNullJson()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         //Test with invalid Json
         HetrixtoolsServiceResponse::fromJson(null);
     }

--- a/composer.json
+++ b/composer.json
@@ -1,36 +1,29 @@
 {
     "name": "azine/mailgunwebhooks-bundle",
     "type": "symfony-bundle",
-    "description": "Symfony Bundle to capture feedback from mailgun.com via their provided webhooks",
+    "description": "Symfony bundle to capture Mailgun webhook events and send delivery-health notifications.",
     "keywords": [
-        "Mailgun",
-        "mailgun.com",
-        "transactional email",
         "email",
+        "mailgun",
+        "symfony",
         "webhooks"
     ],
-    "homepage": "https://github.com/azine/AzineMailgunWebhooksBundle.git",
+    "homepage": "https://github.com/azine/AzineMailgunWebhooksBundle",
     "license": "MIT",
     "authors": [
         {
-            "name": "Azine IT src/Services AG",
+            "name": "Azine IT Services AG",
             "email": "github@azine-it.ch"
         }
     ],
-    "config": {
-        "process-timeout": 590,
-        "sort-packages": true,
-        "preferred-install": {
-            "*": "dist"
-        },
-        "allow-plugins": {
-            "symfony/flex": true
-        }
-    },
     "require": {
         "php": "^8.5",
+        "ext-curl": "*",
+        "ext-json": "*",
         "ext-mailparse": "*",
-        "doctrine/orm": "^3.3",
+        "doctrine/orm": "^3.6",
+        "doctrine/persistence": "^3.3 || ^4.0",
+        "psr/log": "^3.0",
         "symfony/config": "^7.4",
         "symfony/console": "^7.4",
         "symfony/dependency-injection": "^7.4",
@@ -39,11 +32,12 @@
         "symfony/framework-bundle": "^7.4",
         "symfony/http-foundation": "^7.4",
         "symfony/http-kernel": "^7.4",
-        "symfony/process": "^7.4",
+        "symfony/mailer": "^7.4",
+        "symfony/mime": "^7.4",
         "symfony/routing": "^7.4",
         "symfony/translation": "^7.4",
         "symfony/yaml": "^7.4",
-        "twig/twig": "^3.0"
+        "twig/twig": "^3.14"
     },
     "require-dev": {
         "phpunit/phpunit": "^12.0"
@@ -57,6 +51,16 @@
         "psr-4": {
             "Azine\\MailgunWebhooksBundle\\Tests\\": "Tests/"
         }
+    },
+    "config": {
+        "allow-plugins": {
+            "symfony/flex": true
+        },
+        "preferred-install": {
+            "*": "dist"
+        },
+        "process-timeout": 590,
+        "sort-packages": true
     },
     "minimum-stability": "stable",
     "prefer-stable": true

--- a/src/Command/CheckIpAddressIsBlacklistedCommand.php
+++ b/src/Command/CheckIpAddressIsBlacklistedCommand.php
@@ -9,81 +9,42 @@ use Azine\MailgunWebhooksBundle\Services\AzineMailgunMailerService;
 use Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\AzineMailgunHetrixtoolsService;
 use Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\HetrixtoolsServiceResponse;
 use Doctrine\Persistence\ManagerRegistry;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\Process;
 
-/**
- * Checks if the last ip address from MailgunEvent entity is in blacklist.
- */
+#[AsCommand(
+    name: 'mailgun:check-ip-in-blacklist',
+    description: 'Checks whether the most recently used Mailgun sending IP is blacklisted.',
+)]
 class CheckIpAddressIsBlacklistedCommand extends Command
 {
-    const NO_VALID_RESPONSE_FROM_HETRIX = 'No valid response from Hetrixtools service, try later.';
-    const BLACKLIST_REPORT_WAS_SENT = 'Blacklist report was sent.';
-    const BLACKLIST_REPORT_IS_SAME_AS_PREVIOUS = 'Blacklist report contains the same info as the last report that was sent.';
-    const IP_IS_NOT_BLACKLISTED = 'Ip is not blacklisted.';
-    const STARTING_RETRY = 'Initiating retry of the checking command. Tries left: ';
+    public const NO_VALID_RESPONSE_FROM_HETRIX = 'No valid response from Hetrixtools service, try later.';
+    public const BLACKLIST_REPORT_WAS_SENT = 'Blacklist report was sent.';
+    public const BLACKLIST_REPORT_IS_SAME_AS_PREVIOUS = 'Blacklist report contains the same info as the last report that was sent.';
+    public const IP_IS_NOT_BLACKLISTED = 'Ip is not blacklisted.';
+    public const STARTING_RETRY = 'Initiating retry of the checking command. Tries left: ';
 
-    /**
-     * @var string|null The default command name
-     */
-    protected static $defaultName = 'mailgun:check-ip-in-blacklist';
-
-    /**
-     * @var ManagerRegistry
-     */
-    private $managerRegistry;
-
-    /**
-     * @var AzineMailgunHetrixtoolsService
-     */
-    private $hetrixtoolsService;
-
-    /**
-     * @var AzineMailgunMailerService
-     */
-    private $azineMailgunService;
-
-    /**
-     * @var string
-     */
-    private $kernelEnvironment;
-
-    /**
-     * @var int
-     */
-    private $muteDays;
-
-    /**
-     * CheckIpAddressIsBlacklistedCommand constructor.
-     *
-     * @param ManagerRegistry                $managerRegistry
-     * @param AzineMailgunHetrixtoolsService $hetrixtoolsService
-     * @param AzineMailgunMailerService      $azineMailgunService
-     * @param $environment
-     */
-    public function __construct(ManagerRegistry $managerRegistry, AzineMailgunHetrixtoolsService $hetrixtoolsService,
-                                AzineMailgunMailerService $azineMailgunService, $environment, $muteDays)
-    {
-        $this->managerRegistry = $managerRegistry;
-        $this->hetrixtoolsService = $hetrixtoolsService;
-        $this->azineMailgunService = $azineMailgunService;
-        $this->kernelEnvironment = $environment;
-        $this->muteDays = $muteDays;
-
+    public function __construct(
+        private readonly ManagerRegistry $managerRegistry,
+        private readonly AzineMailgunHetrixtoolsService $hetrixtoolsService,
+        private readonly AzineMailgunMailerService $azineMailgunService,
+        private readonly string $kernelEnvironment,
+        private readonly int $muteDays,
+    ) {
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
-        $this
-            ->setName(static::$defaultName)
-            ->setDescription('Checks if the last sending IP address from MailgunEvent entity is in blacklist')
-            ->addArgument('numberOfAttempts',
-                InputArgument::OPTIONAL,
-                'Number of retry attempts in case if there were no response from hetrixtools or the process of checking blacklist was still in progress');
+        $this->addArgument(
+            'numberOfAttempts',
+            InputArgument::OPTIONAL,
+            'Number of retry attempts when Hetrixtools has no response or the blacklist check is still in progress.',
+            0,
+        );
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
@@ -92,111 +53,119 @@ class CheckIpAddressIsBlacklistedCommand extends Command
         /** @var MailgunEventRepository $eventRepository */
         $eventRepository = $manager->getRepository(MailgunEvent::class);
         $ipAddressData = $eventRepository->getLastKnownSenderIpData();
-        $ipAddress = null;
+        $ipAddress = $ipAddressData['ip'] ?? null;
+        $sendDateTime = isset($ipAddressData['timestamp'])
+            ? new \DateTimeImmutable('@'.(string) $ipAddressData['timestamp'])
+            : new \DateTimeImmutable();
+        $attemptsLeft = max(0, (int) $input->getArgument('numberOfAttempts'));
 
-        if (isset($ipAddressData['ip'])) {
-            $ipAddress = $ipAddressData['ip'];
-            $sendDateTime = new \DateTime('@'.$ipAddressData['timestamp']);
+        while (true) {
+            try {
+                $response = $this->hetrixtoolsService->checkIpAddressInBlacklist($ipAddress);
+            } catch (\InvalidArgumentException) {
+                $output->writeln(self::NO_VALID_RESPONSE_FROM_HETRIX);
+
+                if ($attemptsLeft > 0) {
+                    $output->writeln(self::STARTING_RETRY.$attemptsLeft);
+                    --$attemptsLeft;
+                    continue;
+                }
+
+                return Command::FAILURE;
+            }
+
+            if (
+                HetrixtoolsServiceResponse::RESPONSE_STATUS_ERROR === $response->status
+                && HetrixtoolsServiceResponse::BLACKLIST_CHECK_IN_PROGRESS === $response->error_message
+                && $attemptsLeft > 0
+            ) {
+                $output->writeln((string) $response->error_message);
+                $output->writeln(self::STARTING_RETRY.$attemptsLeft);
+                --$attemptsLeft;
+                continue;
+            }
+
+            break;
         }
-        $numberOfAttempts = $input->getArgument('numberOfAttempts');
+
+        if (HetrixtoolsServiceResponse::RESPONSE_STATUS_ERROR === $response->status) {
+            $output->writeln((string) $response->error_message);
+
+            return Command::FAILURE;
+        }
+
+        if (HetrixtoolsServiceResponse::RESPONSE_STATUS_SUCCESS !== $response->status) {
+            $output->writeln(self::NO_VALID_RESPONSE_FROM_HETRIX);
+
+            return Command::FAILURE;
+        }
+
+        if (0 === (int) $response->blacklisted_count) {
+            $output->writeln(self::IP_IS_NOT_BLACKLISTED." ($ipAddress)");
+
+            return Command::SUCCESS;
+        }
+
+        if ($this->muteNotification($response)) {
+            $output->writeln(self::BLACKLIST_REPORT_IS_SAME_AS_PREVIOUS." ($ipAddress)");
+
+            return Command::SUCCESS;
+        }
 
         try {
-            $response = $this->hetrixtoolsService->checkIpAddressInBlacklist($ipAddress);
-        } catch (\InvalidArgumentException $ex) {
-            $output->write(self::NO_VALID_RESPONSE_FROM_HETRIX);
+            $messagesSent = $this->azineMailgunService->sendBlacklistNotification($response, (string) $ipAddress, $sendDateTime);
 
-            if (null != $numberOfAttempts && $numberOfAttempts > 0) {
-                $output->write(self::STARTING_RETRY.$numberOfAttempts);
-                $this->retry($numberOfAttempts);
-            }
+            if ($messagesSent > 0) {
+                $output->writeln(self::BLACKLIST_REPORT_WAS_SENT." ($ipAddress)");
 
-            return -1;
-        }
-
-        if (HetrixtoolsServiceResponse::RESPONSE_STATUS_SUCCESS == $response->status) {
-            if (0 == $response->blacklisted_count) {
-                $output->write(self::IP_IS_NOT_BLACKLISTED." ($ipAddress)");
-            } elseif ($this->muteNotification($response)) {
-                $output->write(self::BLACKLIST_REPORT_IS_SAME_AS_PREVIOUS." ($ipAddress)");
-            } else {
-                try {
-                    $messagesSent = $this->azineMailgunService->sendBlacklistNotification($response, $ipAddress, $sendDateTime);
-
-                    if ($messagesSent > 0) {
-                        $output->write(self::BLACKLIST_REPORT_WAS_SENT." ($ipAddress)");
-                    }
-                    if ($this->muteDays > 0) {
-                        $blacklistResponseNotification = new HetrixToolsBlacklistResponseNotification();
-                        $blacklistResponseNotification->setData($response);
-                        $blacklistResponseNotification->setIp($ipAddress);
-                        $blacklistResponseNotification->setDate($sendDateTime);
-                        $blacklistResponseNotification->setIgnoreUntil(new \DateTime('+'.$this->muteDays.' days'));
-                        $manager = $this->managerRegistry->getManager();
-                        $manager->persist($blacklistResponseNotification);
-                        $manager->flush();
-                    }
-                } catch (\Exception $e) {
-                    $output->write($e->getMessage(), true);
+                if ($this->muteDays > 0) {
+                    $blacklistResponseNotification = new HetrixToolsBlacklistResponseNotification();
+                    $blacklistResponseNotification->setData($response);
+                    $blacklistResponseNotification->setIp($ipAddress);
+                    $blacklistResponseNotification->setDate(\DateTime::createFromImmutable($sendDateTime));
+                    $blacklistResponseNotification->setIgnoreUntil(new \DateTime('+'.$this->muteDays.' days'));
+                    $manager->persist($blacklistResponseNotification);
+                    $manager->flush();
                 }
             }
-        } elseif (HetrixtoolsServiceResponse::RESPONSE_STATUS_ERROR == $response->status) {
-            $output->write($response->error_message);
+        } catch (\Throwable $exception) {
+            $output->writeln($exception->getMessage());
 
-            if (null != $numberOfAttempts && $numberOfAttempts > 0 && HetrixtoolsServiceResponse::BLACKLIST_CHECK_IN_PROGRESS == $response->error_message) {
-                $output->write(self::STARTING_RETRY.$numberOfAttempts);
-                $this->retry($numberOfAttempts);
-            }
-
-            return -1;
+            return Command::FAILURE;
         }
 
-        return 0;
+        return Command::SUCCESS;
     }
 
-    private function retry($numberOfAttempts)
+    private function muteNotification(HetrixtoolsServiceResponse $response): bool
     {
-        --$numberOfAttempts;
-
-        $cmd = sprintf(
-            '%s/console %s %s --env=%s',
-            static::$defaultName,
-            $numberOfAttempts,
-            $this->kernelEnvironment
-        );
-
-        $process = new Process($cmd);
-        $process->start();
-    }
-
-    private function muteNotification($response)
-    {
-        if (0 == $this->muteDays) {
-            // don't mute if feature is disabled
+        if (0 === $this->muteDays) {
             return false;
         }
 
-        $ip = substr($response->links['api_report_link'], strrpos($response->links['api_report_link'], '/', -3) + 1, -1);
-        $responseRepository = $this->managerRegistry->getManager()->getRepository(HetrixToolsBlacklistResponseNotification::class);
+        $apiReportLink = (string) ($response->links['api_report_link'] ?? '');
+        $ip = substr($apiReportLink, strrpos($apiReportLink, '/', -3) + 1, -1);
+        $responseRepository = $this->managerRegistry
+            ->getManager()
+            ->getRepository(HetrixToolsBlacklistResponseNotification::class);
+        $lastNotifiedResponses = $responseRepository->findBy(['ip' => $ip], ['ignoreUntil' => 'desc']);
+
+        if ([] === $lastNotifiedResponses) {
+            return false;
+        }
+
         /** @var HetrixToolsBlacklistResponseNotification $lastNotifiedResponse */
-        $lastNotifiedResponses = $responseRepository->findBy(array('ip' => $ip), array('ignoreUntil' => 'desc'));
-
-        if (0 == sizeof($lastNotifiedResponses)) {
-            // don't mute if this is the first check for this ip
+        $lastNotifiedResponse = $lastNotifiedResponses[0];
+        if ($lastNotifiedResponse->getIgnoreUntil() < new \DateTime()) {
             return false;
         }
 
-        if ($lastNotifiedResponses[0]->getIgnoreUntil() < new \DateTime()) {
-            // don't mute if the last notification it too long ago
-            return false;
-        }
+        $newBlacklists = $response->blacklisted_on;
+        $oldBlacklists = $lastNotifiedResponse->getData()['blacklisted_on'] ?? null;
 
-        $newBlackLists = $response->blacklisted_on;
-        $oldBlacklists = $lastNotifiedResponses[0]->getData()['blacklisted_on'];
-
-        $blacklistsUnchanged = is_array($newBlackLists) && is_array($oldBlacklists)
-            && count($newBlackLists) == count($oldBlacklists)
-            && $newBlackLists == $oldBlacklists;
-
-        return $blacklistsUnchanged;
+        return is_array($newBlacklists)
+            && is_array($oldBlacklists)
+            && count($newBlacklists) === count($oldBlacklists)
+            && $newBlacklists === $oldBlacklists;
     }
 }

--- a/src/Command/CheckIpAddressIsBlacklistedCommand.php
+++ b/src/Command/CheckIpAddressIsBlacklistedCommand.php
@@ -8,7 +8,7 @@ use Azine\MailgunWebhooksBundle\Entity\Repositories\MailgunEventRepository;
 use Azine\MailgunWebhooksBundle\Services\AzineMailgunMailerService;
 use Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\AzineMailgunHetrixtoolsService;
 use Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\HetrixtoolsServiceResponse;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -86,7 +86,7 @@ class CheckIpAddressIsBlacklistedCommand extends Command
                 'Number of retry attempts in case if there were no response from hetrixtools or the process of checking blacklist was still in progress');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $manager = $this->managerRegistry->getManager();
         /** @var MailgunEventRepository $eventRepository */

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -16,7 +16,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder(AzineMailgunWebhooksExtension::PREFIX);
         $rootNode = $this->getRootNode($treeBuilder, AzineMailgunWebhooksExtension::PREFIX);
@@ -55,7 +55,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode(AzineMailgunWebhooksExtension::TICKET_SUBJECT)->defaultValue('IP on spam-list, please fix.')->info('Mailgun HelpDesk ticket subject')->end()
                         ->scalarNode(AzineMailgunWebhooksExtension::TICKET_MESSAGE)->defaultValue('It looks like my ip is on a spam-list. Please, assign a clean IP to my domain.')->info('Mailgun HelpDesk ticket subject')->end()
                         ->scalarNode(AzineMailgunWebhooksExtension::ALERTS_RECIPIENT_EMAIL)->defaultValue('')->info('Admin E-Mail to send notification about spam complaints')->end()
-        ->end();
+                    ->end()
+                ->end()
+            ->end();
     }
 
     /**
@@ -72,7 +74,9 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode(AzineMailgunWebhooksExtension::BLACKLIST_CHECK_API_KEY)->defaultValue('')->info('Your public-api-key for hetrixtools => see https://hetrixtools.com/')->end()
                         ->scalarNode(AzineMailgunWebhooksExtension::BLACKLIST_CHECK_IP_URL)->defaultValue('https://api.hetrixtools.com/v2/<API_TOKEN>/blacklist-check/ipv4/<IP_ADDRESS>/')->info('Url for checking if ip is in blacklist => see https://docs.hetrixtools.com/blacklist-check-api/')->end()
                         ->integerNode(AzineMailgunWebhooksExtension::BLACKLIST_CHECK_IP_REPEAT_NOTIFICATION_DURATION)->defaultValue(0)->info("Number of days to mute the blacklist-notification if the reported blacklists didn't change.")->end()
-        ->end();
+                    ->end()
+                ->end()
+            ->end();
     }
 
     /**

--- a/src/Services/AzineMailgunMailerService.php
+++ b/src/Services/AzineMailgunMailerService.php
@@ -6,228 +6,167 @@ use Azine\MailgunWebhooksBundle\Entity\EmailTrafficStatistics;
 use Azine\MailgunWebhooksBundle\Entity\MailgunEvent;
 use Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\HetrixtoolsServiceResponse;
 use Doctrine\Persistence\ManagerRegistry;
-use Symfony\Component\Translation\TranslatorInterface;
+use Symfony\Component\Mailer\MailerInterface;
+use Symfony\Component\Mime\Address;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\Translation\TranslatorInterface;
+use Twig\Environment;
 
 class AzineMailgunMailerService
 {
     /**
-     * @var \Swift_Mailer
-     */
-    private $mailer;
-
-    /**
-     * @var \Twig_Environment
-     */
-    private $twig;
-
-    /**
-     * @var TranslatorInterface
-     */
-    private $translator;
-
-    /**
-     * @var mixed either string email or array(email => displayName)
-     */
-    private $fromEmail;
-
-    /**
-     * @var string
-     */
-    private $ticketId;
-
-    /**
-     * @var string
-     */
-    private $ticketSubject;
-
-    /**
-     * @var string
-     */
-    private $ticketMessage;
-
-    /**
-     * @var string
-     */
-    private $spamAlertsRecipientEmail;
-
-    /**
-     * @var ManagerRegistry
-     */
-    private $managerRegistry;
-
-    /**
-     * @var int
-     */
-    private $sendNotificationsInterval;
-
-    /**
-     * AzineMailgunMailerService constructor.
-     *
-     * @param \Swift_Mailer $mailer
-     * @param \Twig_Environment $twig
-     * @param TranslatorInterface $translator
-     * @param string $fromEmail
-     * @param string $ticketId
-     * @param string $ticketSubject
-     * @param string $ticketMessage
-     * @param string $spamAlertsRecipientEmail
-     * @param ManagerRegistry $managerRegistry
-     * @param int $sendNotificationsInterval in Seconds
+     * @param string|array<string|string> $fromEmail
      */
     public function __construct(
-        \Swift_Mailer $mailer,
-        \Twig_Environment $twig,
-        TranslatorInterface $translator,
-        $fromEmail,
-        $ticketId,
-        $ticketSubject,
-        $ticketMessage,
-        $spamAlertsRecipientEmail,
-        ManagerRegistry $managerRegistry,
-        $sendNotificationsInterval
-    )
-    {
-        $this->mailer = $mailer;
-        $this->twig = $twig;
-        $this->translator = $translator;
-        $this->fromEmail = $fromEmail;
-        $this->ticketId = $ticketId;
-        $this->ticketSubject = $ticketSubject;
-        $this->ticketMessage = $ticketMessage;
-        $this->spamAlertsRecipientEmail = $spamAlertsRecipientEmail;
-        $this->managerRegistry = $managerRegistry;
-        $this->sendNotificationsInterval = $sendNotificationsInterval;
+        private readonly MailerInterface $mailer,
+        private readonly Environment $twig,
+        private readonly TranslatorInterface $translator,
+        private readonly string|array $fromEmail,
+        private readonly string $ticketId,
+        private readonly string $ticketSubject,
+        private readonly string $ticketMessage,
+        private readonly string $spamAlertsRecipientEmail,
+        private readonly ManagerRegistry $managerRegistry,
+        private readonly int $sendNotificationsInterval,
+    ) {
     }
 
-    /**
-     * @param string $eventId
-     *
-     * @return int $messagesSent
-     * @throws \Exception
-     *
-     */
-    public function sendSpamComplaintNotification($eventId)
+    public function sendSpamComplaintNotification(string|int $eventId): int
     {
-        $messagesSent = 0;
-        $failedRecipients = array();
-
-        $templateVars = array();
-        $templateVars['eventId'] = $eventId;
-        $templateVars['ticketId'] = $this->ticketId;
-
-
-        /** @var \Swift_Message $message */
-        $message = $this->mailer->createMessage();
-        $message->setTo($this->spamAlertsRecipientEmail)
-            ->setFrom($this->fromEmail)
-            ->setSubject($this->translator->trans('notification.spam_complaint_received'))
-            ->setBody($this->twig->render('@AzineMailgunWebhooks/Email/notification.html.twig', $templateVars), 'text/html')
-            ->setBody($this->twig->render('@AzineMailgunWebhooks/Email/notification.txt.twig', $templateVars), 'text/plain');
-
-        $lastSpamReport = $this->managerRegistry->getManager()->getRepository(EmailTrafficStatistics::class)
+        $lastSpamReport = $this->managerRegistry
+            ->getManager()
+            ->getRepository(EmailTrafficStatistics::class)
             ->getLastByAction(EmailTrafficStatistics::SPAM_ALERT_SENT);
 
         if ($lastSpamReport instanceof EmailTrafficStatistics) {
-            $time = new \DateTime();
-            $timeDiff = $time->diff($lastSpamReport->getCreated());
-
-            if ($timeDiff->s > $this->sendNotificationsInterval) {
-                $messagesSent = $this->mailer->send($message, $failedRecipients);
+            $elapsedSeconds = time() - $lastSpamReport->getCreated()->getTimestamp();
+            if ($elapsedSeconds <= $this->sendNotificationsInterval) {
+                return 0;
             }
-        } else {
-            $messagesSent = $this->mailer->send($message, $failedRecipients);
         }
 
-        if ($messagesSent > 0) {
-            $spamAlert = new EmailTrafficStatistics();
-            $spamAlert->setAction(EmailTrafficStatistics::SPAM_ALERT_SENT);
-            $manager = $this->managerRegistry->getManager();
-            $manager->persist($spamAlert);
-            $manager->flush($spamAlert);
-            $manager->clear();
-        }
+        $templateVariables = [
+            'eventId' => $eventId,
+            'ticketId' => $this->ticketId,
+            'ticketSubject' => $this->ticketSubject,
+            'ticketMessage' => $this->ticketMessage,
+        ];
 
-        if (0 == $messagesSent && !empty($failedRecipients)) {
-            throw new \Exception('Tried to send notification about spam complaint but no messages were sent');
-        }
+        $message = $this->createEmail()
+            ->to(...$this->normalizeAddresses($this->spamAlertsRecipientEmail))
+            ->subject($this->translator->trans('notification.spam_complaint_received'))
+            ->html($this->twig->render('@AzineMailgunWebhooks/Email/notification.html.twig', $templateVariables))
+            ->text($this->twig->render('@AzineMailgunWebhooks/Email/notification.txt.twig', $templateVariables));
 
-        return $messagesSent;
+        $this->mailer->send($message);
+
+        $spamAlert = new EmailTrafficStatistics();
+        $spamAlert->setAction(EmailTrafficStatistics::SPAM_ALERT_SENT);
+        $manager = $this->managerRegistry->getManager();
+        $manager->persist($spamAlert);
+        $manager->flush();
+        $manager->clear();
+
+        return 1;
     }
 
-    /**
-     * @param HetrixtoolsServiceResponse $response
-     * @param string $ipAddress
-     * @param \DateTime
-     *
-     * @return int
-     *
-     * @throws \Exception
-     */
-    public function sendBlacklistNotification(HetrixtoolsServiceResponse $response, $ipAddress, \DateTime $sendDateTime)
+    public function sendBlacklistNotification(
+        HetrixtoolsServiceResponse $response,
+        string $ipAddress,
+        \DateTimeInterface $sendDateTime,
+    ): int {
+        $templateVariables = [
+            'response' => $response,
+            'ipAddress' => $ipAddress,
+            'sendDateTime' => $sendDateTime->format('Y-m-d H:i:s'),
+        ];
+
+        $message = $this->createEmail()
+            ->to(...$this->normalizeAddresses($this->spamAlertsRecipientEmail))
+            ->subject($this->translator->trans('notification.blacklist_received'))
+            ->html($this->twig->render('@AzineMailgunWebhooks/Email/blacklistNotification.html.twig', $templateVariables))
+            ->text($this->twig->render('@AzineMailgunWebhooks/Email/blacklistNotification.txt.twig', $templateVariables));
+
+        $this->mailer->send($message);
+
+        return 1;
+    }
+
+    public function sendErrorNotification(MailgunEvent $event): int
     {
-        $sendDateTime = (new \DateTime())->format('Y-m-d H:i:s');
-        $failedRecipients = array();
+        $fromAddress = $event->getEventSummary()->getFromAddress();
+        $originalSenders = $this->extractValidEmail($fromAddress);
 
-        $templateVars = array();
-        $templateVars['response'] = $response;
-        $templateVars['ipAddress'] = $ipAddress;
-        $templateVars['sendDateTime'] = $sendDateTime;
-
-        /** @var \Swift_Message $message */
-        $message = $this->mailer->createMessage();
-        $message->setTo($this->spamAlertsRecipientEmail)
-            ->setFrom($this->fromEmail)
-            ->setSubject($this->translator->trans('notification.blacklist_received'))
-            ->setBody($this->twig->render('@AzineMailgunWebhooks/Email/blacklistNotification.html.twig', $templateVars), 'text/html')
-            ->addPart($this->twig->render('@AzineMailgunWebhooks/Email/blacklistNotification.txt.twig', $templateVars), 'text/plain');
-
-        $messagesSent = $this->mailer->send($message, $failedRecipients);
-
-        if (0 == $messagesSent && !empty($failedRecipients)) {
-            throw new \Exception('Tried to send notification about ip is blacklisted but no messages were sent');
+        if ([] === $originalSenders) {
+            throw new \InvalidArgumentException(sprintf('No valid sender address could be parsed from "%s".', $fromAddress));
         }
 
-        return $messagesSent;
+        $parsedSender = mailparse_rfc822_parse_addresses($fromAddress)[0] ?? [];
+        $templateVariables = [
+            'mailgunEvent' => $event,
+            'mailgunMessageSummary' => $event->getEventSummary(),
+            'recipient' => ['displayName' => (string) ($parsedSender['display'] ?? '')],
+            'sendDateTime' => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
+        ];
+
+        $message = $this->createEmail()
+            ->to(...$originalSenders)
+            ->subject($this->translator->trans(
+                'notification.email.delivery.to.%originalRecipient%.failed',
+                ['%originalRecipient%' => $event->getRecipient()],
+            ))
+            ->html($this->twig->render('@AzineMailgunWebhooks/Email/deliveryErrorNotification.html.twig', $templateVariables))
+            ->text($this->twig->render('@AzineMailgunWebhooks/Email/deliveryErrorNotification.txt.twig', $templateVariables));
+
+        $this->mailer->send($message);
+
+        return 1;
     }
 
-    public function sendErrorNotification(MailgunEvent $event) {
-        $sendDateTime = (new \DateTime())->format('Y-m-d H:i:s');
-        $originalSender = $this->extractValidEmail($event->getEventSummary()->getFromAddress());
-        $eventRecipient = $this->extractValidEmail($event->getRecipient());
-
-        $templateVars = array();
-        $templateVars['mailgunEvent'] = $event;
-        $templateVars['mailgunMessageSummary'] = $event->getEventSummary();
-        $templateVars['recipient'] = array('displayName' => mailparse_rfc822_parse_addresses($event->getEventSummary()->getFromAddress())[0]['display']);
-
-        /** @var \Swift_Message $message */
-        $message = $this->mailer->createMessage();
-        $message->setTo($originalSender)
-            ->setFrom($this->fromEmail)
-            ->setSubject($this->translator->trans('notification.email.delivery.to.%originalRecipient%.failed', ['%originalRecipient%' => $event->getRecipient()]))
-            ->setBody($this->twig->render('@AzineMailgunWebhooks/Email/deliveryErrorNotification.html.twig', $templateVars), 'text/html')
-            ->addPart($this->twig->render('@AzineMailgunWebhooks/Email/deliveryErrorNotification.txt.twig', $templateVars), 'text/plain');
-
-        $messagesSent = $this->mailer->send($message, $failedRecipients);
-
-        if (0 == $messagesSent && !empty($failedRecipients)) {
-            throw new \Exception('Tried to send notification about email delivery error but no messages were sent');
-        }
-
-        return $messagesSent;
+    private function createEmail(): Email
+    {
+        return (new Email())->from(...$this->normalizeAddresses($this->fromEmail));
     }
 
     /**
-     * @param $address
-     * @return string RFC 2822, 3.6.2. compliant email address-array array('receiver@domain.org', 'other@domain.org' => 'A name')
+     * @param string|array<string|string> $addresses
+     *
+     * @return list<Address>
      */
-    private function extractValidEmail($address){
-        $addressParts = mailparse_rfc822_parse_addresses($address);
-        $emails = array();
-        foreach ($addressParts as $next){
-            $emails[$next['address']] = $next['display'];
+    private function normalizeAddresses(string|array $addresses): array
+    {
+        if (is_string($addresses)) {
+            return [new Address($addresses)];
         }
-        return $emails;
+
+        $normalized = [];
+        foreach ($addresses as $email => $name) {
+            if (is_int($email)) {
+                $normalized[] = new Address((string) $name);
+                continue;
+            }
+
+            $normalized[] = new Address((string) $email, (string) $name);
+        }
+
+        return $normalized;
     }
 
+    /**
+     * @return list<Address>
+     */
+    private function extractValidEmail(string $address): array
+    {
+        $addresses = [];
+        foreach (mailparse_rfc822_parse_addresses($address) as $parsedAddress) {
+            $email = (string) ($parsedAddress['address'] ?? '');
+            if ('' === $email || false === filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                continue;
+            }
+
+            $addresses[] = new Address($email, (string) ($parsedAddress['display'] ?? ''));
+        }
+
+        return $addresses;
+    }
 }

--- a/src/Services/AzineMailgunMailerService.php
+++ b/src/Services/AzineMailgunMailerService.php
@@ -5,7 +5,7 @@ namespace Azine\MailgunWebhooksBundle\Services;
 use Azine\MailgunWebhooksBundle\Entity\EmailTrafficStatistics;
 use Azine\MailgunWebhooksBundle\Entity\MailgunEvent;
 use Azine\MailgunWebhooksBundle\Services\HetrixtoolsService\HetrixtoolsServiceResponse;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Symfony\Component\Translation\TranslatorInterface;
 
 class AzineMailgunMailerService

--- a/src/Services/AzineMailgunService.php
+++ b/src/Services/AzineMailgunService.php
@@ -2,7 +2,7 @@
 
 namespace Azine\MailgunWebhooksBundle\Services;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\ORM\EntityManager;
 
 /**


### PR DESCRIPTION
## What changed

- upgrades the bundle to PHP 8.5, Symfony 7.4, Twig 3 and Doctrine ORM 3;
- declares the required `curl`, `json` and `mailparse` PHP extensions;
- migrates notification delivery from Swiftmailer to Symfony Mailer/Mime while preserving the existing service API;
- modernizes Doctrine persistence namespaces, configuration trees and PHPUnit tests;
- replaces the broken recursive subprocess retry command with bounded in-process retry behavior;
- adds GitHub Actions coverage for stable and lowest dependency sets.

## Compatibility

The public notification methods continue to return `1` after a successful delivery and `0` when a throttled spam notification is intentionally skipped. Transport failures now propagate as Symfony Mailer exceptions instead of relying on Swiftmailer's failed-recipient array.

## Validation

GitHub Actions runs Composer validation and PHPUnit on PHP 8.5 for stable and lowest supported dependencies. The branch still needs an application-level integration run together with the Azine.Me upgrade before release.
